### PR TITLE
feat(notification): add a unknownfailure message [OSD-6723]

### DIFF
--- a/osd/Incident_resolved.json
+++ b/osd/Incident_resolved.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Info",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Cluster incident resolved",
+    "description": "cluster incident '${ALERT_NAME}' is resolved.",
+    "internal_only": false
+}

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Cluster is malfunctioning",
+    "description": "cluster was identified to have an general failure regarding the alert names '${ALERT_NAME}'.\n
+                    If you intended for this alert to fire file a support request, if not a diagnosis of the issue is underway",
+    "internal_only": false
+}

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster incident identified",
-    "description": "cluster is identified to have an general failure regarding the alert '${ALERT_NAME}'. The initial issue can be described as '${BRIEF_DESCRIPTION}'. A diagnosis of the issue is underway",
+    "description": "cluster is identified to have a general failure regarding the alert '${ALERT_NAME}'. The initial issue can be described as '${BRIEF_DESCRIPTION}'. A diagnosis of the issue is underway",
     "internal_only": false
 }

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -2,8 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Cluster is malfunctioning",
-    "description": "cluster was identified to have an general failure regarding the alert names '${ALERT_NAME}'.\n
-                    If you intended for this alert to fire file a support request, if not a diagnosis of the issue is underway",
+    "summary": "Cluster incident identified",
+    "description": "cluster is identified to have an general failure regarding the alert '${ALERT_NAME}'. The initial issue can be described as '${BRIEF_DESCRIPTION}'. A diagnosis of the issue is underway",
     "internal_only": false
 }


### PR DESCRIPTION
to accommodate with failures we would want to notify the customer quickly, this servicelog template is in place.
as mostly an alert will provoke us to send a message, the alertname is also in the message