### PR TITLE
Add ROSA_AWS_invalid_permissions.md

### DIFF
--- a/osd/aws/ROSA_AWS_invalid_permissions.md
+++ b/osd/aws/ROSA_AWS_invalid_permissions.md
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR adds a notification for customers whose installation is being blocked as they've either removed or otherwise altered the AWS credentials being used to install the cluster.

I titled this template ROSA-specific in order to link directly to the ROSA-themed documentation, but if there is a different preference for how we should structure such things I'm happy to accomodate.