### PR TITLE
Adding AddressLimitExceeded AWS error notification for EIP addresses

### DIFF
--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on AWS AddressLimitExceeded error. Please raise the EIP addresses quota or remove some EIP addresses for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
+    "internal_only": false
+}


### PR DESCRIPTION
Adding AddressLimitExceeded error that was found during cluster installation. Example:
```
Error creating EIP: AddressLimitExceeded: The maximum number of addresses has been reached.
```