### PR TITLE
Add failing API service notification

### DIFF
--- a/osd/failing_api_service.json
+++ b/osd/failing_api_service.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: correct failing API services",
+    "description": "The '${API_SERVICE}' extension API service installed on your cluster is currently failing. This failing service can impact your cluster's ongoing operation and resource management. Please validate and correct or otherwise remove the failing API Service. If you require assistance, please file a support request.",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a notification for when an API service extension installed by the customer is failing.

A failing API service can have consequences including impact to the cluster's ability to perform garbage collection, which then has been observed to impact the successful operation of cluster and SRE operators.

There is no good product documentation on API service extensions (the best I can find [is this](https://docs.openshift.com/container-platform/4.7/rest_api/extension_apis/extension-apis-index.html)) so unfortunately there isn't much to link to.