### PR TITLE
Add message for recovering master nodes

### DIFF
--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "SRE recovered master nodes",
-    "description" : "SRE have noticed a change in the state of one or more of the cluster's master nodes. SRE have restored the affected nodes. Please note that changing the running state on the master nodes directly from the cloud provider manually is not supported.",
+    "description" : "SRE have noticed a change in the state of one or more of the cluster's master nodes. SRE have restored the affected nodes. Please note that if you change the running state of one of the master nodes manually then SRE won't be able to support your cluster anymore.",
     "internal_only": false
 }

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "SRE recovered master nodes",
-    "description" : "SRE have noticed that some master nodes of your cluster were stopped from the IaaS infrastructure. SRE have started back the nodes to recover the cluster. Please note that stopping master nodes manually is not a supported operation.",
+    "description" : "SRE have noticed a change in the state of one or more of the cluster's master nodes. SRE have restored the affected nodes. Please note that changing the running state on the master nodes directly from the cloud provider manually is not supported.",
     "internal_only": false
 }

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "SRE recovered master nodes",
+    "description" : "SRE have noticed that some master nodes of your cluster were stopped from the IaaS infrastructure. SRE have started back the nodes to recover the cluster. Please note that stopping master nodes manually is not a supported operation.",
+    "internal_only": false
+}


### PR DESCRIPTION
If customer stopped a master node and SRE recover it manually, we should send customer a message and let customer know stopping master node manually is not a support operation.