### PR TITLE
Add suspended support for changes made in openshift namespaces

### DIFF
--- a/osd/cluster_support_suspended_ns.json
+++ b/osd/cluster_support_suspended_ns.json
@@ -2,7 +2,7 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Cluster support suspended: none-authorised changes in openshift-* namespace detected",
-    "description": "Openshift Dedicated SRE team has noticed some none-supported changes that were made to the openshift-* namespace. This cluster will no longer be monitored and managed by the SRE team. Possible causes may include configuration changes to openshift-* namespaces, etc. If you wish to resume support for this cluster, please submit a support ticket.",
+    "summary": "Cluster support suspended: non-authorised changes in openshift-* namespace detected",
+    "description": "Openshift Dedicated SRE team has noticed some non-supported changes that were made to the openshift-* namespace. This cluster will no longer be monitored and managed by the SRE team. Possible causes may include configuration changes to openshift-* namespaces, etc. If you wish to resume support for this cluster, please submit a support ticket.",
     "internal_only": false
 }

--- a/osd/cluster_support_suspended_ns.json
+++ b/osd/cluster_support_suspended_ns.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster support suspended: non-authorised changes in openshift-* namespace detected",
-    "description": "Openshift Dedicated SRE team has noticed some non-supported changes that were made to the openshift-* namespace. This cluster will no longer be monitored and managed by the SRE team. Possible causes may include configuration changes to openshift-* namespaces, etc. If you wish to resume support for this cluster, please submit a support ticket.",
+    "description": "Openshift Dedicated SRE team has noticed some non-supported changes that were made to the openshift-* namespace. This is a reserved namespace that should not be tampered with and as a consequence this cluster will no longer be monitored and managed by the SRE team. If you wish to resume support for this cluster, please submit a support ticket.",
     "internal_only": false
 }

--- a/osd/cluster_support_suspended_ns.json
+++ b/osd/cluster_support_suspended_ns.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Cluster support suspended: none-authorised changes in openshift-* namespace detected",
+    "description": "Openshift Dedicated SRE team has noticed some none-supported changes that were made to the openshift-* namespace. This cluster will no longer be monitored and managed by the SRE team. Possible causes may include configuration changes to openshift-* namespaces, etc. If you wish to resume support for this cluster, please submit a support ticket.",
+    "internal_only": false
+}


### PR DESCRIPTION
Similar to https://github.com/openshift/managed-notifications/pull/11/   customers may change the config in openshift-* namespace, which may break the cluster.

@cattias @wgordon17 Could you help to review and comment?