### PR TITLE
Adding message for an unsupported second ingress controller

### DIFF
--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: update cluster configuration",
+    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not supported. Please remove the second ingress controller. This article may address your usecase: https://access.redhat.com/articles/5599621.",
+    "internal_only": false
+}


### PR DESCRIPTION
Adding message for an unsupported second ingress controller, followup from https://coreos.slack.com/archives/CCX9DB894/p1619516683014000