### PR TITLE
Added Elasticsearch Cluster not enough resources error

### DIFF
--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -1,0 +1,9 @@
+{
+ "severity": "Error",
+ "service_name": "SREManualAction",
+ "cluster_uuid": "${CLUSTER_UUID}",
+ "summary": "Action required: Elasticsearch unable to start due to resource limits",
+ "description": "Your cluster requires you to take action. Your OpenShift Dedicated cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/dedicated/4/logging/dedicated-cluster-deploying.html",
+ "internal_only": false
+}
+


### PR DESCRIPTION
On investigating https://redhat.pagerduty.com/incidents/PZMSWIJ, we found that the customer did not have a big enough cluster to run elastic search.

According to documentation: https://docs.openshift.com/dedicated/4/logging/dedicated-cluster-deploying.html, we recommend running more nodes to resolve this problem.

@mrbarge and I drafted and sent the service log to the customer and have moved here for it to be added as a template for future use.