### PR TITLE
Added OperatorMisconfigured.json

### DIFF
--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,0 +1,8 @@
+{
+ "severity": "Error",
+ "service_name": "SREManualAction",
+ "cluster_uuid": "${CLUSTER_UUID}",
+ "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
+ "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance",
+ "internal_only": false
+}


### PR DESCRIPTION
On https://redhat.pagerduty.com/incidents/PM2J3CV

We found the a customer installed operator in the `openshift-operators-redhat` namespace is misconfigured, hence, @mrbarge and I wrote this template for all notification for misconfigured operators