### PR TITLE
Adding generic AWS/GCP Quota Exceeded templates

### DIFF
--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the installation to succeed. AWS account limits are described in this document -  https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
+    "internal_only": false
+}

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/4.6/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds generic "quota exceeded" templates for AWS and GCP.  This may be better than attempting to have a template for each different type of quota that can be an issue.