### PR TITLE
Make the Generic Quota Exceeded template more generic

### DIFF
--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -2,7 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the installation to succeed. AWS account limits are described in this document -  https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
+    "summary": "Action required: review account quota",
+    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_QuotaExceeded.json
+++ b/osd/aws/InstallFailed_QuotaExceeded.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
+    "internal_only": false
+}

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -2,7 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/4.6/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
+    "summary": "Action required: review account quota",
+    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
     "internal_only": false
 }

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR introduces generic 'quota exceeded' templates more generic to handle situations where the quota has been exceeded in situations that don't involve the cluster installation. For example, making `CLUSTER_FUNCTION` equal to `ability to create IngressControllers`.

The 'documentation' links for all quota-related templates have also been updated to point to 4.7-release documentation.