### PR TITLE
Adding service log message for unsupported workload on master/infra node

### DIFF
--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Remove custom workload from master/infra nodes",
+    "description": "Your cluster requires you to take action because there is a custom workload scheduled on master/infra nodes. As per Red Hat OpenShift Dedicated Service Definition, the master and infrastructure nodes are strictly for Red Hat workloads to operate the service. Please refer https://www.openshift.com/products/dedicated/service-definition#compute-instances.",
+    "internal_only": false
+}

--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -2,7 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Action required: Remove custom workload from master/infra nodes",
-    "description": "Your cluster requires you to take action because there is a custom workload scheduled on master/infra nodes. As per Red Hat OpenShift Dedicated Service Definition, the master and infrastructure nodes are strictly for Red Hat workloads to operate the service. Please refer https://www.openshift.com/products/dedicated/service-definition#compute-instances.",
+    "summary": "Action required: Remove custom workload from control plane/infra nodes",
+    "description": "Your cluster requires you to take action because there is a custom workload scheduled on control plane/infra nodes. As per Red Hat OpenShift Dedicated Service Definition, the control plane and infrastructure nodes are strictly for Red Hat workloads to operate the service. Please refer https://www.openshift.com/products/dedicated/service-definition#compute-instances.",
     "internal_only": false
 }


### PR DESCRIPTION
This message is raised out of findings from [OHSS-3928](https://issues.redhat.com/browse/OHSS-3928) where customer scheduled pods on infra nodes. This is against OSD Service Policy. 