### PR TITLE
Add template for issues around Pod Security Policies

### DIFF
--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Remove or update pod security configuration",
+    "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a new template to cover the scenario of a cluster owner having installed Pod Security Security policies which impact the cluster's operation.

As PSPs are a deprecated feature and not used in OpenShift, the template points the cluster owner towards a KB article around this topic.