### PR TITLE
add action for misconfigured custom domain

### DIFF
--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: update custom domain configuration",
+    "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation : https://access.redhat.com/articles/5599621",
+    "internal_only": false
+}


### PR DESCRIPTION
As part of PD#264983 found that the customer has misconfigured their custom domain, this message notifies the customer with the link to docs for custom domain setup