### PR TITLE
Add template for when the cluster owner is disabled

### DIFF
--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Arrange new cluster owner",
+    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support ticket with Red Hat to nominate a new owner for the cluster in https://cloud.redhat.com/openshift/",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR adds a template to inform the customer that their current cluster owner in OCM is disabled. This situation, when it occurs, results in the cluster's inability to communicate back to api.openshift.com, which impacts its ability to upgrade or report telemetry.

