### PR TITLE
Adding "generic problem" template.

### DIFF
--- a/osd/generic_problem_notification.json
+++ b/osd/generic_problem_notification.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: ${PROBLEM_SUMMARY}",
+    "description": "Your cluster requires you to take action because ${PROBLEM}, resulting in ${IMPACT}. Without action, your cluster's SLA may be impacted, along with any ability to upgrade. Please refer to this documentation for more information: ${DOCUMENTATION}. If you require assistance, please file a support request.",
+    "internal_only": false
+}


### PR DESCRIPTION
I feel like many of our notifications can be essentially distilled down into this form.

For example, I have used this template today for a problem around a cluster's pull secret being modified.

- PROBLEM_SUMMARY="Cluster pull secret modified." 
- PROBLEM="'cloud.openshift.com' has been removed from your cluster's global pull-secret" 
- IMPACT="stability issues with OpenShift Marketplace and reporting to cloud.openshift.com." 
- DOCUMENTATION="https://docs.openshift.com/container-platform/4.7/openshift_images/managing_images/using-image-pull-secrets.html"

Resulting in:

```
Your cluster requires you to take action because 'cloud.openshift.com' has been removed from your cluster's global pull-secret, resulting in stability issues with OpenShift Marketplace and reporting to cloud.openshift.com. Without action, your cluster's SLA may be impacted, along with any ability to upgrade. Please refer to this documentation for more infomation: https://docs.openshift.com/container-platform/4.7/openshift_images/managing_images/using-image-pull-secrets.html. If you require assistance, please file a support request.
```