### PR TITLE
Cleanup Ingress Controller servicelog messages

### DIFF
--- a/osd/Ingress-Controllers.json
+++ b/osd/Ingress-Controllers.json
@@ -1,8 +1,0 @@
-{
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Action required: Update ingress controller configuration",
-    "description": "Your cluster has a misconfigured ingress-controller. Please delete the ingress controller and create a new one that does not conflict. See ingress-controller documentation for details: https://docs.openshift.com/container-platform/4.7/networking/ingress-operator.html#configuring-ingress-controller",
-    "internal_only": false
-}

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update cluster configuration",
-    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not supported. Please remove the second ingress controller. This article may address your usecase: https://access.redhat.com/articles/5599621.",
+    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not supported. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://access.redhat.com/articles/5599621.",
     "internal_only": false
 }


### PR DESCRIPTION
Currently, there are two Ingress Controller SL messages. This PR removes one of them, which was inaccurate, and changes the language of the other to explicitly mention the Custom Domain operator