### PR TITLE
InstallFailed due to IAM policies

### DIFF
--- a/osd/aws/InstallFailed_lambda_automation_interfering.json
+++ b/osd/aws/InstallFailed_lambda_automation_interfering.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to automation in your AWS account which is interfering with the installation. ${REASON} Please remove or prevent this automation to allow installation to succeed. If you require further assistance please file a support request.",
+    "internal_only": false
+}


### PR DESCRIPTION
Add managed notification to notify customer on blocked installation due to due to automation in AWS account which is interfering with the installation