### PR TITLE
Add ElasticsearchClusterMisconfigured.json

### DIFF
--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -1,0 +1,8 @@
+{
+ "severity": "Error",
+ "service_name": "SREManualAction",
+ "cluster_uuid": "${CLUSTER_UUID}",
+ "summary": "Action required: review cluster logging configuration",
+ "description": "Your cluster's ElasticSearch deployment is misconfigured in a way that is impacting its operation. ${REASON} For more information, please consult the following documentation reference: https://docs.openshift.com/dedicated/4/logging/dedicated-cluster-deploying.html",
+ "internal_only": false
+}


### PR DESCRIPTION
We had a case of a cluster owner deploying cluster logging but placing bad values in the clusterlogging CR that they have to create. (inserting a bad `storageClassName`).

This template is a generic "you've misconfigured this, here's the documentation if you need it" template for logging. (still pointing at the OSD4 docs for now).