### PR TITLE
Added sl for validating webhook alerts

### DIFF
--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Platform protections removed by non-Red Hat user",
+    "description": "A user on your system has removed a platform protection webhook. Tampering with platform protections can endanger SLAs. Please open a support case so that we can better understand your goals and use cases, https://access.redhat.com/support.",
+    "internal_only": false
+}


### PR DESCRIPTION
This service log is used to notify customers they are attempting to remove platform protection webhook to be used with the following SOP https://github.com/openshift/ops-sop/blob/master/v4/alerts/SplunkNonSystemChangeValidatingWebhookConfigurations.md