### PR TITLE
tweak "non-Red Hat user" language

### DIFF
--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -2,7 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Platform component accessed by non-Red Hat user",
-    "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat. Tampering with platform components can endanger SLAs. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
+    "summary": "Platform component accessed by non-Red Hat SRE user",
+    "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
     "internal_only": false
 }


### PR DESCRIPTION
change "non-Red Hat user" language to "non-Red Hat SRE". Clusters can be owned by Red Hatters, so sometimes it is a Red Hat user making a manual change. When a Red Hatter gets this SL, it makes them anxious they've been hacked.

/assign @csheremeta @fahlmant 
