### PR TITLE
Fixed URL for ElasticSearch SLs.

### DIFF
--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -3,6 +3,6 @@
  "service_name": "SREManualAction",
  "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: review cluster logging configuration",
- "description": "Your cluster's ElasticSearch deployment is misconfigured in a way that is impacting its operation. ${REASON} For more information, please consult the following documentation reference: https://docs.openshift.com/dedicated/4/logging/dedicated-cluster-deploying.html",
+ "description": "Your cluster's ElasticSearch deployment is misconfigured in a way that is impacting its operation. ${REASON} For more information, please consult the following documentation reference: https://docs.openshift.com/container-platform/4.8/logging/cluster-logging.html",
  "internal_only": false
 }

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -2,8 +2,8 @@
  "severity": "Error",
  "service_name": "SREManualAction",
  "cluster_uuid": "${CLUSTER_UUID}",
- "summary": "Action required: Elasticsearch unable to start due to resource limits",
- "description": "Your cluster requires you to take action. Your OpenShift Dedicated cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/dedicated/4/logging/dedicated-cluster-deploying.html",
+ "summary": "Action required: Elasticsearch impacted by cluster resource limits",
+ "description": "Your cluster requires you to take action. Your OpenShift Dedicated cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/container-platform/4.8/logging/config/cluster-logging-log-store.html#cluster-logging-logstore-limits_cluster-logging-store",
  "internal_only": false
 }
 


### PR DESCRIPTION
This PR fixes the URL used for ElasticSearch-related communications to point to the OCP documentation rather than OSD documentation, as any references to ElasticSearch-based logging have been removed from the OSD docs.