### PR TITLE
add cluster proxy misconfiguration

### DIFF
--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: update cluster proxy configuration",
+    "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/networking/enable-cluster-wide-proxy",
+    "internal_only": false
+}


### PR DESCRIPTION
Note that currently cluster-wide proxy feature is not supported outside user-provisioned infrastructure installation and this SL is for the future, otherwise we're advising customer to fix something that is not supported