### PR TITLE
Parameterise namespace name of the second monitoring stack installed by the customer

### DIFF
--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: remove second monitoring stack",
-    "description" : "Red Hat SRE have noticed a second monitoring stack installed in the ‘monitoring’ namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/osd-understanding-the-monitoring-stack.html",
+    "description" : "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/osd-understanding-the-monitoring-stack.html",
     "internal_only": false
 }


### PR DESCRIPTION
The customer can (and has) install the second invalid monitoring stack in any arbitrary namespace. This should be a parameter.