### PR TITLE
Add user-webhook-impacting-cluster SL

### DIFF
--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: review platform webhook configurations",
+    "description": "Your cluster requires you to take action because custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster. Please review the webhooks installed and verify they are running correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. If you require further assistance please open a support case.",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a template for when a cluster owner has installed their own validating webhooks which impact API performance or cluster stability.