### PR TITLE
Add SL regarding updating pull secret

### DIFF
--- a/osd/update_pull_secret.json
+++ b/osd/update_pull_secret.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Review pull secret",
+    "description": "Your cluster requires you to take action because the cluster is reporting that it is unauthorized to pull images from ${REGISTRY}. Without this, image pulls from that registry will not succeed and may impact Red Hat SRE's ability to monitor and support your cluster. Please ensure that the cluster's global pull secret is using correct authentication for the ${REGISTRY} registry. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/4.8/openshift_images/managing_images/using-image-pull-secrets.html . If you require further assistance please file a support request.",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a SL template for when a cluster owner has invalidated their pull secret for a registry (ie. registry.redhat.io).
