### PR TITLE
Adding an SL for when required network egress resources are blocked

### DIFF
--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Network misconfigration",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. The ability to pull pod images is impacted, as is SRE's ability to monitor and support your cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites We request that you revert changes or contact support for more assistance.",
+    "internal_only": false
+}


### PR DESCRIPTION
Adding an SL template for when internet egress resources are unavailable. We've seen this all too often on PrivateLink clusters, sometimes weeks after a successful install.