### PR TITLE
Add cloud incident resolution message

### DIFF
--- a/osd/aws/aws_outage_resolved.json
+++ b/osd/aws/aws_outage_resolved.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "cluster_uuid": "${CLUSTER_UUID}",
+  "summary": "RESOLVED: AWS Outage Impacting Your Cluster",
+  "description": "The AWS outage impacting your cluster has been resolved. For more details, including incident resolution, see https://status.aws.amazon.com/",
+  "internal_only": false
+}

--- a/osd/gcp/GCP_outage _resolved.json
+++ b/osd/gcp/GCP_outage _resolved.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Info",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "RESOLVED: GCP Outage Impacting Your Cluster",
+    "description": "The GCP outage impacting your cluster has been resolved. For more details, including incident resolution, see https://status.cloud.google.com/",
+    "internal_only": false
+}


### PR DESCRIPTION
After sending bulk messages to customers impacted by cloud provider outage, we also should inform them when the outage is resolved. This PR adds messages for both GCP and AWS that can be used after the cloud provider set their incident to `resolved`.