### PR TITLE
Changing SRE suggestion from remove to review

### DIFF
--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Network misconfigration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster: ${CHANGE}. Please revert changes or contact support for more assistance.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster: ${CHANGE}. Please review changes or contact support for more assistance.",
     "internal_only": false
 }


### PR DESCRIPTION
Different customers would have different requirements/constraints so SRE suggestion can be made neutral and let customer decide what to do next. 