### PR TITLE
New Notification: Reduce resource consumption of openshift-pipelines

### DIFF
--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Resources overloaded",
+    "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/4.9/cicd/pipelines/reducing-pipelines-resource-consumption.html",
+    "internal_only": false
+   }
+


### PR DESCRIPTION
Pipeline runs can cause nodes to become overwhelmed, SRE should provide specific guidance.