### PR TITLE
adding bucket request rate error

### DIFF
--- a/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
+++ b/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation blocked on AWS error: 'Error creating S3 bucket: SlowDown: Please reduce your request rate.' The S3 bucket request rate will need to be lowered to within AWS request limits in order for the installaiton to succeed. AWS S3 request limits are described in this document - https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/",
+    "internal_only": false
+}


### PR DESCRIPTION
This addresses cases where a customer account has a bucket with a very high amount of requests, which causes the installation to fail.