### PR TITLE
adding GCP cluster provisioning failure: oauth2 token error

### DIFF
--- a/osd/aws/sts_deleted_provider.json
+++ b/osd/aws/sts_deleted_provider.json
@@ -1,7 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Fix AWS Role to maintain SRE support",
+  "summary": "Action required: Review OpenIDConnect provider configuration",
   "description": "Your cluster requires you to take action because the OpenIDConnect provider for this cluster could not be found. Please revert any changes to the OIDC provider to maintain ongoing cluster support.",
   "internal_only": false
 }

--- a/osd/gcp/InstallFailed_CannotFetchToken.json
+++ b/osd/gcp/InstallFailed_CannotFetchToken.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked on a GCP token error: 'oauth2: cannot fetch token https://oauth2.googleapis.com/token'. Please try the installation again. If you require assistance or if the error recurs, please file a support request at https://access.redhat.com/support.",
+    "internal_only": false
+}

--- a/osd/infranode_resized.json
+++ b/osd/infranode_resized.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Info",
+    "service_name": "SREManualAction",
+    "event_stream_id": "${JIRA_ID}",
+    "summary": "Infra nodes resized",
+    "description" : "SRE has observed ${JUSTIFICATION}. SRE has resized the infra nodes of your cluster to ${INSTANCE_TYPE} to accommodate cluster load",
+    "internal_only": false
+}


### PR DESCRIPTION
Token acquisition error which prevents a GCP OSD cluster from provisioning.