### PR TITLE
OSD-9325: remove cluster_uuid from message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Notification templates for OpenShift Managed services
 
 ## Usage
 
-Select the corresopnding message and send as a `POST` to
+Select the corresponding message and send it as a `POST` to
 [api.openshift.com servicelog](https://api.openshift.com/?urls.primaryName=Service%20logs#/default/post_api_service_logs_v1_cluster_logs).
-`CLUSTER_UUID` is a required parameter.
 
 > :warning: Please review each template before post to make sure all the parameters are passed with -p 
 
@@ -20,11 +19,13 @@ Using [osdctl](https://github.com/openshift/osdctl)
 1. Post servicelog
 
     ```
-    osdctl servicelog post -t <notificationTemplateUrl> -p CLUSTER_UUID=<UUID>
+    osdctl servicelog post <clusterID> -t <notificationTemplateUrl> 
     ```
 
     Example:
 
     ```
-    osdctl servicelog post -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json -p CLUSTER_UUID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+    osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
     ```
+
+Note: `Osdctl` supports the usage of the unique cluster name, or the internal- and external ID as clusterID.

--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Arrange new cluster owner",
     "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support ticket with Red Hat to nominate a new owner for the cluster in https://cloud.redhat.com/openshift/",
     "internal_only": false

--- a/osd/AlertmanagerSilencesActiveSRE.json
+++ b/osd/AlertmanagerSilencesActiveSRE.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "AlertManager Silences Identified",
     "description": "Cluster has been identified with AlertManager silences. Silences prevent Red Hat from effectively monitoring this cluster and will be removed.",
     "internal_only": false

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Bad MachineConfigPool Configuration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made the cluster MachineConfigPool. ${REASON}. Please revert changes or consult the documentation: https://docs.openshift.com/rosa/nodes/rosa-managing-worker-nodes.html for details.",
     "internal_only": false

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster ingress degraded",
     "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster. Please work with Red Hat support to help remediate this issue.",
     "internal_only": false

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
   "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift Dedicated version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342",
   "internal_only": false

--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: review cluster logging configuration",
  "description": "Your cluster's ElasticSearch deployment is misconfigured in a way that is impacting its operation. ${REASON} For more information, please consult the following documentation reference: https://docs.openshift.com/container-platform/latest/logging/cluster-logging.html",
  "internal_only": false

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Elasticsearch impacted by cluster resource limits",
  "description": "Your cluster requires you to take action. Your OpenShift Dedicated cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/container-platform/latest/logging/config/cluster-logging-log-store.html#cluster-logging-logstore-limits_cluster-logging-store",
  "internal_only": false

--- a/osd/ElasticsearchClusterNotHealthy_Error.json
+++ b/osd/ElasticsearchClusterNotHealthy_Error.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "event_stream_id": "${EVENT_STREAM_ID}",
  "summary": "Urgent action required: update cluster logging configuration",
  "description": "Your cluster requires you to take action. Elasticsearch storage is greater than 95% utilized, and data loss is imminent. Red Hat SRE strongly recommends reducing application logging on your cluster to ensure logging continues to function.",

--- a/osd/ElasticsearchClusterNotHealthy_Warning.json
+++ b/osd/ElasticsearchClusterNotHealthy_Warning.json
@@ -1,7 +1,6 @@
 {
  "severity": "Warning",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "event_stream_id": "${EVENT_STREAM_ID}",
  "summary": "Action required: update cluster logging configuration",
  "description": "Your cluster requires you to take action. Elasticsearch storage is greater than 85% utilized. If this goes above 95%, data might will be lost. SRE will increase capacity one time causing a period while Elasticsearch is unavailable. Old logs will be retained. Logs for pods deleted while migration is in progress may be lost. SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",

--- a/osd/Failed_Logins.json
+++ b/osd/Failed_Logins.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "There are an elevated number of failed logins on your cluster",
     "description": "The Red Hat Site Reliability Engineering (SRE) team detected a security event on your Managed OpenShift cluster. There are an elevated number of failed logins on your cluster(s) from user ${USERNAME}. Red Hat SRE is sending this notice to you for further analysis. Please review OpenShift Authentication for configuration information https://docs.openshift.com/container-platform/latest/authentication/understanding-authentication.html",
     "internal_only": false

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation failed",
     "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
     "internal_only": false

--- a/osd/KubePersistentVolumeFillingUpError-user.json
+++ b/osd/KubePersistentVolumeFillingUpError-user.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Persistent Volume filling",
     "description": "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp' in '${NAMESPACE}'. This is not an actionable alert for the SRE team. Please address this PV capacity issue using this reference documentation: https://docs.openshift.com/dedicated/4/storage/expanding-persistent-volumes.html",
     "internal_only": false

--- a/osd/KubePersistentVolumeFillingUpError.json
+++ b/osd/KubePersistentVolumeFillingUpError.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Urgent action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch is at ${PERCENT}% load. Red Hat SRE strongly recommends immediately reducing application logging on your cluster to ensure logging continues to function in the near future. If logging stack stops functioning the logging stack will need reprovisioned to recover and application logs will be lost.",
     "internal_only": false

--- a/osd/KubePersistentVolumeFillingUpWarn.json
+++ b/osd/KubePersistentVolumeFillingUpWarn.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch is on average at ${PERCENT}% load. If this goes above 95%, data might will be lost. SRE will increase capacity one time causing a period while Elasticsearch is unavailable. Old logs will be retained. Logs for pods deleted while migration is in progress may be lost. SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",
     "internal_only": false

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Network misconfigration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster: ${CHANGE}. Please review changes or contact support for more assistance.",
     "internal_only": false

--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Non-Red Hat Access Core Secrets",
     "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
     "internal_only": false

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Non-System Change SRE API Endpoint",
     "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
     "internal_only": false

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "OCM3018 Installation blocked, action required",
     "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-creating-cluster.html for more information.",
     "internal_only": false

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
  "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance",
  "internal_only": false

--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Platform component accessed by non-Red Hat SRE user",
     "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
     "internal_only": false

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Remove or update pod security configuration",
     "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051",
     "internal_only": false

--- a/osd/RHOAMInstallNeedsMoreResources.json
+++ b/osd/RHOAMInstallNeedsMoreResources.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "event_stream_id": "${JIRA_ID}",
     "summary": "Action required: Add resources to complete RHOAM installation",
     "description": "Your cluster does not have sufficient resources to install the Red Hat OpenShift API Management add-on. Please reference https://access.redhat.com/articles/5534341 and provide the necessary resources to complete the installation.",

--- a/osd/RecoveryOfDeletedMaster.json
+++ b/osd/RecoveryOfDeletedMaster.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Recovery of deleted master nodes is not supported.",
     "description" : "SRE have noticed that one or more master nodes have been deleted manually. Please note that recovery of deleted master nodes is not supported. Changing the running state of one of the master nodes manually will result in loss of cluster functionality and will impact your cluster's SLAs. SRE kindly suggests that you reinstall the cluster to return it to the desired state.",
     "internal_only": false

--- a/osd/ResourceIsRaisingClusterAlert.json
+++ b/osd/ResourceIsRaisingClusterAlert.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is triggering a alert",
  "description": "Your cluster requires you to take action. The resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is causing the alert ${ALERTNAME} to fire. Please ${ACTION_REQUIRED} in order to return the cluster back to normal operations",
  "internal_only": false

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation failed (invalid IAM roles)",
     "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_getting_started/rosa-creating-cluster.html.",
     "internal_only": false

--- a/osd/StuckNewBuilds3MinSRE.json
+++ b/osd/StuckNewBuilds3MinSRE.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update cluster build configuration",
     "description": "Your cluster requires you to take action. Container image builds are failing and must be resolved. Please check the image build error logs and update your configuration. For more information refer to https://docs.openshift.com/dedicated/4/builds/understanding-image-builds.html",
     "internal_only": false

--- a/osd/User_Forbidden.json
+++ b/osd/User_Forbidden.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Elevated rate of failed authorization events on your Managed OpenShift cluster",
     "description": "The Red Hat Site Reliability Engineering (SRE) team detected a security event on your Managed OpenShift cluster. There are an elevated number of API calls that failed authorization for the following users on your cluster: ${USERNAME}. Because the users belong to your organization, Red Hat SRE is sending this notice to you for further analysis.",
     "internal_only": false

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Adjust trusted build configuration",
     "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html . Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/aws/AWS_outage.json
+++ b/osd/aws/AWS_outage.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "AWS Outage Impacting Your Cluster",
     "description": "Red Hat has identified an AWS issue that may impact your cluster. For more details, including incident resolution, see https://status.aws.amazon.com/",
     "internal_only": false

--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on AWS AddressLimitExceeded error. Please raise the EIP addresses quota or remove some EIP addresses for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false

--- a/osd/aws/AlertmanagerSilencesActiveSRE.json
+++ b/osd/aws/AlertmanagerSilencesActiveSRE.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Clear Alertmanager Silences",
     "description": "Your cluster's monitoring stack has silenced alerts. This prevents Red Hat SRE from monitoring this cluster. Please clear alert silences immediately.",
     "internal_only": false

--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: review account quota",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false

--- a/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
+++ b/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS error: 'Error creating S3 bucket: SlowDown: Please reduce your request rate.' The S3 bucket request rate will need to be lowered to within AWS request limits in order for the installaiton to succeed. AWS S3 request limits are described in this document - https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/",
     "internal_only": false

--- a/osd/aws/InstallFailed_InvalidSubnet.json
+++ b/osd/aws/InstallFailed_InvalidSubnet.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations",
   "internal_only": false

--- a/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
+++ b/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Inspection of the configuration showed one or more NAT gateways are located in private subnets, but they should be located in public subnets. Please review the network configuration, and try re-installing the cluster. AWS VPC requirements are described in this document - https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-vpc.html",
     "internal_only": false

--- a/osd/aws/InstallFailed_NetworkMisconfigured.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Please review the network configuration, and try re-installing the cluster. AWS VPC requirements are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html. If you require further assistance please open a support case.",
     "internal_only": false

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites If you require further assistance please open a support case.",
     "internal_only": false

--- a/osd/aws/InstallFailed_QuotaExceeded.json
+++ b/osd/aws/InstallFailed_QuotaExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on an AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false

--- a/osd/aws/InstallFailed_RoleDeletionFailed.json
+++ b/osd/aws/InstallFailed_RoleDeletionFailed.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked. The cluster installer was not able to delete the roles it used during the installation. To unblock, please ensure that no policies are added to new roles by default.",
   "internal_only": false

--- a/osd/aws/InstallFailed_STS_PrivateLink.json
+++ b/osd/aws/InstallFailed_STS_PrivateLink.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations",
   "internal_only": false

--- a/osd/aws/InstallFailed_SecurityGroupBeingModified.json
+++ b/osd/aws/InstallFailed_SecurityGroupBeingModified.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked as security groups used to provision the cluster on the AWS account were modified during installation. Please review any scripts which would modify the AWS resources automatically on the AWS account. Please make sure the required ports/protocols are allowed at all times. For more information please consult the documentation: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#rosa-security-groups_prerequisites.  If you require further assistance please file a support request.",
     "internal_only": false

--- a/osd/aws/InstallFailed_TooManyBucketObjectTags.json
+++ b/osd/aws/InstallFailed_TooManyBucketObjectTags.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked because S3 objects can only have 10 object tags. Please reduce the number of tags used on S3 objects in your AWS account and retry the installation. AWS S3 object tag limits are described in this document - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html",
     "internal_only": false

--- a/osd/aws/InstallFailed_TooManyBuckets.json
+++ b/osd/aws/InstallFailed_TooManyBuckets.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS TooManyBuckets error. Please raise the S3 bucket quota or remove some buckets from the appropriate region of your AWS account for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false

--- a/osd/aws/InstallFailed_lambda_automation_interfering.json
+++ b/osd/aws/InstallFailed_lambda_automation_interfering.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to automation in your AWS account which is interfering with the installation. ${REASON} Please remove or prevent this automation to allow installation to succeed. If you require further assistance please file a support request.",
     "internal_only": false

--- a/osd/aws/ROSA_AWS_invalid_permissions.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html",
     "internal_only": false

--- a/osd/aws/VPCLimitExceeded.json
+++ b/osd/aws/VPCLimitExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS VpcLimitExceeded error. Please raise the VPC quota or remove some VPCs from the appropriate region of your AWS account for the installation to succeed. AWS account limits are described in this document -  https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account",
     "internal_only": false

--- a/osd/aws/aws_outage_resolved.json
+++ b/osd/aws/aws_outage_resolved.json
@@ -1,7 +1,6 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "RESOLVED: AWS Outage Impacting Your Cluster",
   "description": "The AWS outage impacting your cluster has been resolved. For more details, including incident resolution, see https://status.aws.amazon.com/",
   "internal_only": false

--- a/osd/aws/sts_thumbprint.json
+++ b/osd/aws/sts_thumbprint.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Action required: update cluster OIDC thumbprint",
   "description": "OpenShift SREs have detected your OpenIDConnect Provider thumbprint has changed. Please follow the documentation to update your thumbprint: https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-creating-cluster.html#rosa-sts-creating-cluster under OIDC 1.a Create the OIDC provider. Update the OIDC thumbprint with the command 'aws iam update-open-id-connect-provider-thumbprint', or through the AWS Console under IAM -> Identity Providers.",
   "internal_only": false

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Address Security Context Constraint configuration",
  "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/cluster_alerting_with_no_sre_access.json
+++ b/osd/cluster_alerting_with_no_sre_access.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Attention requested: Cluster account access unavailable",
     "description": "SRE has been notified of problems on your cluster, but cannot investigate because cloud provider access has been removed. If you intended to terminate this cluster then please delete the cluster in the Red Hat console. Otherwise file a support request.",
     "internal_only": false

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster destroyed, cannot be recovered",
     "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/4/getting_started/deleting-your-cluster.html",
     "internal_only": false

--- a/osd/cluster_has_gone_missing.json
+++ b/osd/cluster_has_gone_missing.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: cluster not checking in",
     "description": "Your cluster requires you to take action because it is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopping instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console. Otherwise file a support request.",
     "internal_only": false

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update cluster configuration",
     "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not supported. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html",
     "internal_only": false

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -1,7 +1,6 @@
 {
  "severity": "Warning",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Resources overloaded",
  "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/4/getting_started/scaling-your-cluster.html",
  "internal_only": false

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update cluster proxy configuration",
     "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html",
     "internal_only": false

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update custom domain configuration",
     "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation : https://access.redhat.com/articles/5599621",
     "internal_only": false

--- a/osd/customer_alert_blocking_upgrade.json
+++ b/osd/customer_alert_blocking_upgrade.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Alert is blocking a cluster upgrade",
     "description": "Your cluster requires you to take action because ${PROBLEM} is generating an alert, blocking a cluster upgrade. Without action, your cluster's SLA may be impacted. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -1,7 +1,6 @@
 {
  "severity": "Warning",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Pod emptydir storage preventing Node Drain",
  "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/dedicated/4/storage/understanding-ephemeral-storage.html#storage-ephemeral-storage-typesunderstanding-ephemeral-storage",
  "internal_only": false

--- a/osd/customer_pdb_preventing_drain.json
+++ b/osd/customer_pdb_preventing_drain.json
@@ -1,7 +1,6 @@
 {
  "severity": "Warning",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Pod Disruption Budget preventing Node Drain",
  "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring",
  "internal_only": false

--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Revert modifications to default Security Context Contraints",
     "description": "The cluster's default Security Context Constraints (SCC) have been modified. Please revert the changes to the default SCC or contact support for more assistance. Your cluster's SLA and ability to upgrade may be impacted if you do not take action. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
     "internal_only": false

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: DNS misconfigration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impacts normal working of the cluster. Please revert changes or contact support for more assistance.",
     "internal_only": false

--- a/osd/failing_api_service.json
+++ b/osd/failing_api_service.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: correct failing API services",
     "description": "The '${API_SERVICE}' extension API service installed on your cluster is currently failing. This failing service can impact your cluster's ongoing operation and resource management. Please validate and correct or otherwise remove the failing API Service. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/gcp/GCP_Network_Misconfig.json
+++ b/osd/gcp/GCP_Network_Misconfig.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Failed Openshift Installation on GCP",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Please review the network configuration, and try re-installing the cluster. GCP VPC requirements are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html",
     "internal_only": false

--- a/osd/gcp/GCP_outage _resolved.json
+++ b/osd/gcp/GCP_outage _resolved.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "RESOLVED: GCP Outage Impacting Your Cluster",
     "description": "The GCP outage impacting your cluster has been resolved. For more details, including incident resolution, see https://status.cloud.google.com/",
     "internal_only": false

--- a/osd/gcp/GCP_outage.json
+++ b/osd/gcp/GCP_outage.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "GCP Outage Impacting Your Cluster",
     "description": "Red Hat has identified a GCP issue that may impact your cluster. For more details, including incident resolution, see https://status.cloud.google.com/",
     "internal_only": false

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: review account quota",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
     "internal_only": false

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account",
     "internal_only": false

--- a/osd/generic_customer_support_case_notification.json
+++ b/osd/generic_customer_support_case_notification.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Support case ${CASE_ID}",
     "description": "Your cluster requires you to take action because ${PROBLEM}, resulting in ${IMPACT}. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this customer support case https://access.redhat.com/support/cases/#/case/${CASE_ID} .",
     "internal_only": false

--- a/osd/generic_install_failed.json
+++ b/osd/generic_install_failed.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked because ${PROBLEM}. Please review and validate the following documentation to enable the installation to succeed: ${DOCUMENTATION}. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/generic_problem_notification.json
+++ b/osd/generic_problem_notification.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: ${PROBLEM_SUMMARY}",
     "description": "Your cluster requires you to take action because ${PROBLEM}, resulting in ${IMPACT}. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: ${DOCUMENTATION}. If you require assistance, please file a support request.",
     "internal_only": false

--- a/osd/hive_migration.json
+++ b/osd/hive_migration.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "${DATE} Upcoming Maintenance: OpenShift Cluster Manager actions will be unavailable during this maintenance",
     "description": "The ability to modify your cluster through OpenShift Cluster Manager will be affected by an upcoming maintenance on ${DATE} at ${TIME} UTC. We expect this maintenance to last ${DURATION}. During this maintenance, you will be unable to perform actions such as add or remove nodes, configure administrators, add or remove identity providers, etc. We recommend that you perform any such actions prior to this maintenance.",
     "internal_only": false

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: update identity provider configuration",
     "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html",
     "internal_only": false

--- a/osd/ignore_previous_message.json
+++ b/osd/ignore_previous_message.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Please ignore previous message",
     "description" : "Previous message was sent in error. Please ignore it.",
     "internal_only": false

--- a/osd/incident_resolved.json
+++ b/osd/incident_resolved.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster incident resolved",
     "description": "cluster incident '${ALERT_NAME}' is resolved.",
     "internal_only": false

--- a/osd/incorrect_PodDisruptionBudget.json
+++ b/osd/incorrect_PodDisruptionBudget.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action Required: Incorrect Pod Disruption Budget configuration",
     "description" : "SRE have noticed that your cluster's workload ${WORKLOAD} is using a Pod Disruption Budget (PDB) configuration which can affect the cluster's operation. A maxUnavailable of 0% or 0 or a minAvailable of 100% or equal to the number of replicas is permitted but can block nodes from being drained, hence cluster upgrades can also be impacted. We recommend reviewing your Pod Disruption Budget configurations using the documentation guidelines for setting PDB https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring" 
 }

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Restore missing cloud credentials",
     "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install, or file a support request.",
     "internal_only": false

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -2,7 +2,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Action required: Fix AWS Role to maintain SRE support",
   "description": "Your cluster requires you to take action because Red Hat OpenShift SRE are not able to access your AWS account due to ${REASON} in ${IAM_ROLE_NAME} IAM role that prevents SRE from supporting your cluster. Please fix the IAM role to maintain ongoing cluster support. If you intended to terminate this cluster then please delete the cluster, otherwise file a support request.",
   "internal_only": false

--- a/osd/maintenance_completed.json
+++ b/osd/maintenance_completed.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "${DATE} Cluster maintenance successfully completed",
     "description": "${DATE} cluster maintenance is now successfully completed. Your cluster services are now fully back online, if you require any assistance from Red Hat please open a support ticket.",
     "internal_only": false

--- a/osd/master_resized.json
+++ b/osd/master_resized.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Master nodes resized",
     "description" : "SRE has resized the master nodes of your cluster to ${INSTANCE_TYPE} to accomodate cluster load",
     "internal_only": false

--- a/osd/osd_too_old_upgrade_needed.json
+++ b/osd/osd_too_old_upgrade_needed.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Upgrade cluster before ${CUTOFF_DATE}",
     "description": "Your cluster is running a soon to be unsupported OSD version. Please upgrade to a supported version of OSD before ${CUTOFF_DATE}. Failing to upgrade will result in your cluster becoming unsupported and SRE monitoring of it being disabled, per our Life Cycle Policy, available at https://access.redhat.com/support/policy/updates/openshift/dedicated",
     "internal_only": false

--- a/osd/persistentvolume_resized.json
+++ b/osd/persistentvolume_resized.json
@@ -1,7 +1,6 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Persistent Volume/s Resized",
     "description": "Red Hat SRE have detected a high usage of storage on the ${STORAGE_LOCATION} due to ${REASON_FOR_USAGE} so to avoid losing data Red Hat SRE have reduced the retention to ${NEW_RETENTION_DURATION}. Please take action if you wish to increase the retention again. If you need any assistance please open a support ticket",
     "internal_only": false

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Resources overloaded",
     "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/4.9/cicd/pipelines/reducing-pipelines-resource-consumption.html",
     "internal_only": false

--- a/osd/recover_master_node_is_required.json
+++ b/osd/recover_master_node_is_required.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster does not have sufficient number of master nodes",
     "description" : "SRE have noticed a change in the state of one or more of the cluster's master nodes. Please note that if you change the running state of one of the master nodes manually this may impact the stability of the cluster and the cluster's SLA. We suggest you to revert any changes made on master instances.",
     "internal_only": false

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "SRE recovered master nodes",
     "description" : "SRE has noticed a change in the state of one or more of the cluster's master nodes. SRE has restored the affected nodes. Please note that changing the running state of one of the master nodes manually will result in loss of cluster functionality and will impact your cluster's SLAs.",
     "internal_only": false

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Network misconfigration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. The ability to pull pod images is impacted, as is SRE's ability to monitor and support your cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites We request that you revert changes or contact support for more assistance.",
     "internal_only": false

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Installation blocked, action required",
     "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-creating-cluster.html",
     "internal_only": false

--- a/osd/rosa_cluster_cannot_be_recovered.json
+++ b/osd/rosa_cluster_cannot_be_recovered.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster destroyed, cannot be recovered",
     "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/rosa/rosa_getting_started/rosa-deleting-cluster.html",
     "internal_only": false

--- a/osd/rosa_cluster_destroyed_cluster_admin.json
+++ b/osd/rosa_cluster_destroyed_cluster_admin.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster destroyed, cannot be recovered",
     "description" : "SRE have noticed that the core configuration of your cluster has been modified by a user leveraging cluster-admin permissions. The cluster cannot be restored to a managed state, please delete it following the documentation guidelines: https://docs.openshift.com/rosa/rosa_getting_started/rosa-deleting-cluster.html. Please open a support case if you need any assistance.",
     "internal_only": false

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -1,7 +1,6 @@
 {
  "severity": "Error",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Update Cluster Logging configuration",
  "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation via 'Verification steps' section mentioned in doc: https://docs.openshift.com/rosa/logging/rosa-install-logging.html#rosa-install-logging-addon_rosa-install-logging",
  "internal_only": false

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Invalid TLS certificate",
     "description" : "Your cluster uses an invalid TLS certificate. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains for OpenShift Dedicated at https://access.redhat.com/articles/5599621.",
     "internal_only": false

--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: remove second monitoring stack",
     "description" : "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/osd-understanding-the-monitoring-stack.html",
     "internal_only": false

--- a/osd/security_update_available.json
+++ b/osd/security_update_available.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Important security update available",
     "description": "Your cluster has an important security update available. Details are available at ${ADVISORY_URL}",
     "internal_only": false

--- a/osd/silence_namespace_alerts_notice.json
+++ b/osd/silence_namespace_alerts_notice.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "NOTICE: Silencing alerts for 'openshift-*' user namespaces",
     "description": "The Red Hat SRE team monitors all OpenShift Dedicated namespaces matching pattern 'openshift-*'. This namespace prefix is reserved for infrastructure use. Red Hat SRE does not monitor user namespaces matching this pattern. Alerts for namespace '${NAMESPACE}' have been silenced and will not be re-enabled. Cluster metrics and alerts may still be accessed from the cluster console.",
     "internal_only": false

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Address storageclass configuration",
     "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please restore 'gp2' as the cluster's default storage class by following the 'Storage Class Annotations' instructions in the OpenShift documentation: https://docs.openshift.com/container-platform/latest/post_installation_configuration/storage-configuration.html If you require further assistance, please file a support request.",
     "internal_only": false

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Cluster incident identified",
     "description": "Your cluster is identified to have a general failure regarding the alert '${ALERT_NAME}'. The initial issue can be described as '${BRIEF_DESCRIPTION}'. A diagnosis of the issue is underway",
     "internal_only": false

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,7 +1,6 @@
 {
  "severity": "Warning",
  "service_name": "SREManualAction",
- "cluster_uuid": "${CLUSTER_UUID}",
  "summary": "Action required: Unschedulable customer workload pod",
  "description": "Your OpenShift Dedicated cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html",
  "internal_only": false

--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Remove custom workload from control plane/infra nodes",
     "description": "Your cluster requires you to take action because there is a custom workload scheduled on control plane/infra nodes. As per Red Hat OpenShift Dedicated Service Definition, the control plane and infrastructure nodes are strictly for Red Hat workloads to operate the service. Please refer https://www.openshift.com/products/dedicated/service-definition#compute-instances.",
     "internal_only": false

--- a/osd/update_pull_secret.json
+++ b/osd/update_pull_secret.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: Review pull secret",
     "description": "Your cluster requires you to take action because the cluster is reporting that it is unauthorized to pull images from ${REGISTRY}. Without this, image pulls from that registry will not succeed and may impact Red Hat SRE's ability to monitor and support your cluster. Please ensure that the cluster's global pull secret is using correct authentication for the ${REGISTRY} registry. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html . If you require further assistance please file a support request.",
     "internal_only": false

--- a/osd/upgrade_cluster_version.json
+++ b/osd/upgrade_cluster_version.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action Required: Upgrade cluster version",
     "description": "Red Hat has identified a bug on the current version of your cluster, ${CURRENT_VERSION}. You can review the details of this bug at ${BZ_LINK}. Red Hat recommends you upgrade as soon as possible to the latest available ${LATEST_VERSION} release.",
     "internal_only": false

--- a/osd/upgrade_paused_acknowledgement.json
+++ b/osd/upgrade_paused_acknowledgement.json
@@ -1,7 +1,6 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action Required: Cluster upgrade paused, requires acknowledgement",
     "description": "Your cluster's upgrade cannot proceed because manual acknowledgement is required concerning the removal of deprecated APIs. Please review the Knowledge Base article at https://access.redhat.com/articles/6329921 and perform the recommended acknowledgement procedure if you are not using workloads that require the deprecated APIs and wish to proceed with the upgrade - the upgrade will then proceed as normal. If you require any assistance, please file a support request.",
     "internal_only": false

--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Platform protections removed by non-Red Hat user",
     "description": "A user on your system has removed a platform protection webhook. This protection has already been automatically replaced, and no further action is required. Tampering with platform protections can endanger SLAs. Please open a support case so that we can better understand your goals and use cases, https://access.redhat.com/support.",
     "internal_only": false

--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -1,7 +1,6 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
     "summary": "Action required: review platform webhook configurations",
     "description": "Your cluster requires you to take action because custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster. Please review the webhooks installed and verify they are running correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. If you require further assistance please open a support case.",
     "internal_only": false

--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -1,7 +1,6 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Action required: Fix workload deployed in a restricted project",
   "description": "Your cluster requires you to take action. The ${CUSTOMER_WORKLOAD} has been deployed in the ${RESTRICTED_PROJECT} project which is a reserved project for cluster's infrastructure components. Other components are unlikely to function properly in this reserved project and should be installed to a different one. Please refer to https://docs.openshift.com/dedicated/4/applications/projects/working-with-projects.html to learn more about working with projects",
   "internal_only": false


### PR DESCRIPTION
Remove the CLUSTER_UUID field from the templates. This field is from now on updated by osdctl without the need to define it in the input json as part of https://github.com/openshift/osdctl/pull/174
