### PR TITLE
Fix hyperlink to point to a working, relevant page

### DIFF
--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -2,6 +2,6 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Fix workload deployed in a restricted project",
-  "description": "Your cluster requires you to take action. The ${CUSTOMER_WORKLOAD} has been deployed in the ${RESTRICTED_PROJECT} project which is a reserved project for cluster's infrastructure components. Other components are unlikely to function properly in this reserved project and should be installed to a different one. Please refer to https://docs.openshift.com/dedicated/4/applications/projects/working-with-projects.html to learn more about working with projects",
+  "description": "Your cluster requires you to take action. The ${CUSTOMER_WORKLOAD} has been deployed in the ${RESTRICTED_PROJECT} project which is a reserved project for cluster's infrastructure components. Other components are unlikely to function properly in this reserved project and should be installed to a different one. Please refer to https://docs.openshift.com/container-platform/latest/applications/projects/working-with-projects.html to learn more about working with projects",
   "internal_only": false
  }


### PR DESCRIPTION
The previous URL eventually redirects to a page that is no longer relevant: https://docs.openshift.com/dedicated/4/applications/projects/working-with-projects.html