### PR TITLE
Add user-ca-bundle_invalid.json

### DIFF
--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Info",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: Misconfigured additional Trusted CA bundle",
+    "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html .",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a new template for when a customer has added a corrupt `user-ca-bundle` CA Bundle ConfigMap to their cluster.
When OSD/ROSA cluster-wide proxy documentation exists (currently being authored) this can be updated to reference an actual documentation link.