### PR TITLE
Add notification template when PL cluster is missing egress route from their private subnet, failing install

### DIFF
--- a/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
+++ b/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation is blocked due to there being no egress route defined in your cluster's private subnet. Please review the network configuration, and try re-installing the cluster. You can also refer to the following documentation about the requirements for AWS PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-privatelink-creating-cluster.html#osd-aws-privatelink-required-resources.adoc_rosa-aws-privatelink-creating-cluster",
+  "internal_only": false
+}
+


### PR DESCRIPTION
This has happened multiple times (more than 4 times)  when the customer installs a private link cluster with no route to the internet from their private subnet which is essential for the installation to succeed.