### PR TITLE
Adding Pull Secret change notification

### DIFF
--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: Review pull secret",
+    "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is no longer present in the pull secret. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads . For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
+    "internal_only": false
+}


### PR DESCRIPTION
We have occasions where a customer will change the cluster's pull secret and remove or invalidate the `cloud.redhat.com` token; this will cause the `UpgradeConfigSyncTimeout4HrSRE` alert and inability to publish metrics to telemeter.
This SL informs the CU of that and what their next actions should be.