### PR TITLE
Fixing 404-ing documentation links

### DIFF
--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Bad MachineConfigPool Configuration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made the cluster MachineConfigPool. ${REASON}. Please revert changes or consult the documentation: https://docs.openshift.com/rosa/nodes/rosa-managing-worker-nodes.html for details.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made the cluster MachineConfigPool. ${REASON}. Please revert changes or consult the documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html for details.",
     "internal_only": false
 }

--- a/osd/KubePersistentVolumeFillingUpError-user.json
+++ b/osd/KubePersistentVolumeFillingUpError-user.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Persistent Volume filling",
-    "description": "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp' in '${NAMESPACE}'. This is not an actionable alert for the SRE team. Please address this PV capacity issue using this reference documentation: https://docs.openshift.com/dedicated/4/storage/expanding-persistent-volumes.html",
+    "description": "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp' in '${NAMESPACE}'. This is not an actionable alert for the SRE team. Please address this PV capacity issue using this reference documentation: https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html",
     "internal_only": false
 }

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "OCM3018 Installation blocked, action required",
-    "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html for more information.",
+    "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html for more information.",
     "internal_only": false
 }

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "OCM3018 Installation blocked, action required",
-    "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-creating-cluster.html for more information.",
+    "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html for more information.",
     "internal_only": false
 }

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation failed (invalid IAM roles)",
-    "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html",
+    "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#rosa-policy-iam_prerequisites",
     "internal_only": false
 }

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation failed (invalid IAM roles)",
-    "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_getting_started/rosa-creating-cluster.html.",
+    "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html",
     "internal_only": false
 }

--- a/osd/StuckNewBuilds3MinSRE.json
+++ b/osd/StuckNewBuilds3MinSRE.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: update cluster build configuration",
-    "description": "Your cluster requires you to take action. Container image builds are failing and must be resolved. Please check the image build error logs and update your configuration. For more information refer to https://docs.openshift.com/dedicated/4/builds/understanding-image-builds.html",
+    "description": "Your cluster requires you to take action. Container image builds are failing and must be resolved. Please check the image build error logs and update your configuration. For more information refer to https://docs.openshift.com/container-platform/latest/cicd/builds/understanding-image-builds.html",
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites",
+    "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites",
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
+++ b/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
@@ -2,7 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation is blocked due to there being no egress route defined in your cluster's private subnet. Please review the network configuration, and try re-installing the cluster. You can also refer to the following documentation about the requirements for AWS PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-privatelink-creating-cluster.html#osd-aws-privatelink-required-resources.adoc_rosa-aws-privatelink-creating-cluster",
+  "description": "Your cluster's installation is blocked due to there being no egress route defined in your cluster's private subnet. Please review the network configuration, and try re-installing the cluster. You can also refer to the following documentation about the requirements for AWS PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-aws-privatelink-creating-cluster.html#osd-aws-privatelink-required-resources.adoc_rosa-aws-privatelink-creating-cluster",
   "internal_only": false
 }
 

--- a/osd/aws/InstallFailed_SecurityGroupBeingModified.json
+++ b/osd/aws/InstallFailed_SecurityGroupBeingModified.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked as security groups used to provision the cluster on the AWS account were modified during installation. Please review any scripts which would modify the AWS resources automatically on the AWS account. Please make sure the required ports/protocols are allowed at all times. For more information please consult the documentation: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#rosa-security-groups_prerequisites.",
+    "description": "Your cluster's installation is blocked as security groups used to provision the cluster on the AWS account were modified during installation. Please review any scripts which would modify the AWS resources automatically on the AWS account. Please make sure the required ports/protocols are allowed at all times. For more information please consult the documentation: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#rosa-security-groups_prerequisites.",
     "internal_only": false
 }

--- a/osd/aws/ROSA_AWS_invalid_permissions.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html",
+    "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html",
     "internal_only": false
 }

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Cluster destroyed, cannot be recovered",
-    "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/4/getting_started/deleting-your-cluster.html",
+    "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/osd_quickstart/osd-quickstart.html#deleting-cluster_osd-getting-started",
     "internal_only": false
 }

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Resources overloaded",
- "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/4/getting_started/scaling-your-cluster.html",
+ "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html",
  "internal_only": false
 }

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Pod emptydir storage preventing Node Drain",
- "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/dedicated/4/storage/understanding-ephemeral-storage.html#storage-ephemeral-storage-typesunderstanding-ephemeral-storage",
+ "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/4.10/storage/understanding-ephemeral-storage.html",
  "internal_only": false
 }

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Pod emptydir storage preventing Node Drain",
- "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/4.10/storage/understanding-ephemeral-storage.html",
+ "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/latest/storage/understanding-ephemeral-storage.html",
  "internal_only": false
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. The ability to pull pod images is impacted, as is SRE's ability to monitor and support your cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. The ability to pull pod images is impacted, as is SRE's ability to monitor and support your cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
     "internal_only": false
 }

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -2,7 +2,7 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-creating-cluster.html",
+    "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs",
     "internal_only": false
 }
 

--- a/osd/rosa_cluster_cannot_be_recovered.json
+++ b/osd/rosa_cluster_cannot_be_recovered.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Cluster destroyed, cannot be recovered",
-    "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/rosa/rosa_getting_started/rosa-deleting-cluster.html",
+    "description" : "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html",
     "internal_only": false
 }

--- a/osd/rosa_cluster_destroyed_cluster_admin.json
+++ b/osd/rosa_cluster_destroyed_cluster_admin.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Cluster destroyed, cannot be recovered",
-    "description" : "SRE have noticed that the core configuration of your cluster has been modified by a user leveraging cluster-admin permissions. The cluster cannot be restored to a managed state, please delete it following the documentation guidelines: https://docs.openshift.com/rosa/rosa_getting_started/rosa-deleting-cluster.html. Please open a support case if you need any assistance.",
+    "description" : "SRE have noticed that the core configuration of your cluster has been modified by a user leveraging cluster-admin permissions. The cluster cannot be restored to a managed state, please delete it following the documentation guidelines: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html. Please open a support case if you need any assistance.",
     "internal_only": false
 }

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -2,7 +2,7 @@
  "severity": "Error",
  "service_name": "SREManualAction",
  "summary": "Action required: Update Cluster Logging configuration",
- "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation via 'Verification steps' section mentioned in doc: https://docs.openshift.com/rosa/logging/rosa-install-logging.html#rosa-install-logging-addon_rosa-install-logging",
+ "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation via 'Verification steps' section mentioned in doc: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_logging/rosa-install-logging.html",
  "internal_only": false
 }
 

--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: remove second monitoring stack",
-    "description" : "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/osd-understanding-the-monitoring-stack.html",
+    "description" : "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.html",
     "internal_only": false
 }


### PR DESCRIPTION
A recent documentation shuffle has broken or invalidated a lot of links used in our notification templates - either rehoming them into different OSD/ROSA links or removing them altogether due to unnecessary duplication with OCP documentation.

This PR fixes as many of the ones as I was able to find.