### PR TITLE
Add template when customer has not followed the correct steps to setup BYOK in ROSA

### DIFF
--- a/osd/aws/invalid_kms_policy_byok.json
+++ b/osd/aws/invalid_kms_policy_byok.json
@@ -1,0 +1,7 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Review KMS policy for master instance role",
+  "description": "Your cluster requires you to take action because SRE monitoring stack persistent volume claims are failing to provision, resulting in Red Hat SRE not being able to monitor your cluster. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://access.redhat.com/articles/6155612.",
+  "internal_only": false
+}


### PR DESCRIPTION
This particular case has occured multiple times (>6 times, based on slack history) in the past and we have resorted to proactive cases. I think a simple message directly to the customer like this should suffice.