### PR TITLE
template for drain failures due to standalone customer pods

### DIFF
--- a/osd/customer_pod_preventing_drain.json
+++ b/osd/customer_pod_preventing_drain.json
@@ -1,0 +1,7 @@
+{
+ "severity": "Warning",
+ "service_name": "SREManualAction",
+ "summary": "Action required: Pod(s) preventing Node Drain",
+ "description": "Your cluster is attempting to drain a node but there are pod(s) preventing the drain. The SRE team has identified the pod(s) as '${POD}' running in namespace(s) '${NAMESPACE}'. Please re-schedule the impacted pod(s) so that the node can drain. If you require assistance, please file a support request.",
+ "internal_only": false
+}

--- a/osd/customer_pod_preventing_drain.json
+++ b/osd/customer_pod_preventing_drain.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Pod(s) preventing Node Drain",
- "description": "Your cluster is attempting to drain a node but there are pod(s) preventing the drain. The SRE team has identified the pod(s) as '${POD}' running in namespace(s) '${NAMESPACE}'. Please re-schedule the impacted pod(s) so that the node can drain. If you require assistance, please file a support request.",
+ "description": "Your cluster is attempting to drain a node but there are pod(s) preventing the drain. The SRE team has identified the pod(s) as '${POD}' running in namespace(s) '${NAMESPACE}'. Please re-schedule the impacted pod(s) so that the node can drain.",
  "internal_only": false
 }


### PR DESCRIPTION
We have https://github.com/openshift/managed-notifications/blob/master/osd/customer_pdb_preventing_drain.json which is similar but this is a different case when the drain stalls due to customer pods that are not backed by replicaset/deployment etc or stuck Terminating for a different reason.

I have used this a few times in the past.

Credits to @mrbarge  as he came up with this about 5 months ago...