### PR TITLE
Add template when install fails due to missing route to internet

### DIFF
--- a/osd/aws/InstallFailed_NoRouteToInternet.json
+++ b/osd/aws/InstallFailed_NoRouteToInternet.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked: Missing route to internet",
+  "description": "Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc.",
+  "internal_only": false,
+  "event_stream_id": ""
+}


### PR DESCRIPTION
Our service logs should really be more helpful for the customer than the generic https://github.com/openshift/managed-notifications/blob/master/osd/aws/InstallFailed_NetworkMisconfigured.json

This particular case is quite common too and occurs for BYO-VPC clusters where the customer doesn't have route to internet from the supplied (commonly private) subnet for installation. 

Used this a few times myself.