### PR TITLE
make the egress blocked wording more general

### DIFF
--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. The ability to pull pod images is impacted, as is SRE's ability to monitor and support your cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
     "internal_only": false
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impacts normal working of the cluster, including lack of network egress to Internet-based resources which are required for cluster operation and support. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to the internet-based resources which are required for the cluster operation and support. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. Please revert changes.",
     "internal_only": false
 }


### PR DESCRIPTION
"The ability to pull pod images is impacted" is not always true.