### PR TITLE
Add new service log for MNMO alert.

### DIFF
--- a/osd/BadMachinePoolTaint.json
+++ b/osd/BadMachinePoolTaint.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: Incorrect MachinePool Configuration",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made to one of the cluster MachinePools. This prevents changes made to taints or labels to be propagated to nodes, which can impact scheduling of your workloads. ${REASON}. Please revert the changes.",
+    "internal_only": false
+}


### PR DESCRIPTION
This is part of the changes for [OSD-9911](https://issues.redhat.com//browse/OSD-9911) and is used if the alert is
triggered, due to invalid configuration changes of the MachineSet taints.

Additional information about why this alert is added - https://github.com/openshift/ops-sop/pull/1905