### PR TITLE
Generic STS permission notification

### DIFF
--- a/osd/aws/sts_generic_role_misconfiguration.json
+++ b/osd/aws/sts_generic_role_misconfiguration.json
@@ -1,0 +1,6 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Verify AWS Roles to maintain SRE support",
+  "description": "Openshift SRE is experiencing trouble performing this action for cluster maintenance: '${ACTION}' . Please verify that your AWS IAM policies are in accordance with this documentation to maintain ongoing cluster support: https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html",
+ }


### PR DESCRIPTION
This template is intended for use when SRE is unable to perform basic SRE tasks as some STS permissions are obviously off, and it is not possible to easily find which role exactly is misconfigured. Provide which action you are unable to perform in support of the request.