### PR TITLE
Add templates for when a proxy is configured but needs a CA

### DIFF
--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: update cluster proxy configuration",
+    "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration ",
+    "internal_only": false
+}

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: update cluster proxy configuration",
+    "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration ",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR adds ROSA and OSD templates for when a cluster is configured with a cluster-wide proxy that requires the proxy's CA to also be added to the cluster in order to correctly authenticate traffic.