### PR TITLE
Create ClusterGoneMissing_FirewallIssue

### DIFF
--- a/osd/aws/ClusterGoneMissing_FirewallIssue
+++ b/osd/aws/ClusterGoneMissing_FirewallIssue
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: review firewall configuration",
+  "description": "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to changes in firewall configuration. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. If you need further assistance, please contact Red Hat Support.",
+  "internal_only": false,
+  "event_stream_id": ""
+}

--- a/osd/aws/ClusterGoneMissing_FirewallIssue
+++ b/osd/aws/ClusterGoneMissing_FirewallIssue
@@ -2,7 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: review firewall configuration",
-  "description": "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to changes in firewall configuration. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites. If you need further assistance, please contact Red Hat Support.",
+  "description": "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to the firewall configuration. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites.",
   "internal_only": false,
   "event_stream_id": ""
 }


### PR DESCRIPTION
Cluster is healthy but shows as gone missing due to unreachable red hat endpoints. 

There's no template currently that points out this specific cause for a generic cluster. 

Here's a precedence for this case:

https://coreos.slack.com/archives/CCX9DB894/p1653094497934989

It was approved for this scenario: 

https://coreos.slack.com/archives/CCX9DB894/p1653155689813559?thread_ts=1653078590.418789&cid=CCX9DB894