### PR TITLE
docs: add the case when the installation fails due to sca not available

### DIFF
--- a/osd/failed_to_pull_SCA.json
+++ b/osd/failed_to_pull_SCA.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation is blocked because it failed to pull SCA certs. Please review and validate the following documentation to enable the installation to succeed: https://access.redhat.com/articles/simple-content-access where you can enable SCA.",
+  "internal_only": false,
+  "event_stream_id": ""
+}


### PR DESCRIPTION
Cluster installation fails if the customer didn't enable sca: 

e.g
```shell
    msg=Cluster operator insights SCANotAvailable is True with NotFound: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: OCM API https://api.openshift.com/api/accounts_mgmt/v1/certificates returned HTTP 404: {\"id\":\"7\",\"kind\":\"Error\",\"href\":\"/api/accounts_mgmt/v1/errors/7\",\"code\":\"ACCT-MGMT-7\",\"reason\":\"The organization (id= 21j9LwHTYRS8SqoIRshxyRFkcIM) does not have any certificate of type sca. Enable SCA at https://access.redhat.com/management.\",\"operation_id\":\"ce804952-8012-4f78-9d6d-a5538dc35e3a\"}\nlevel=info 
```

This PR adds SL for it: https://access.redhat.com/articles/simple-content-access