### PR TITLE
Update wording of SCC change notification

### DIFF
--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Revert modifications to default Security Context Contraints",
-    "description": "The cluster's default Security Context Constraints (SCC) have been modified. Please revert the changes to the default SCC. Your cluster's SLA and ability to upgrade may be impacted if you do not take action. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
+    "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
     "internal_only": false
 }


### PR DESCRIPTION
Customers are now prevented via webhooks from altering the default SCCs, so our Service Log wording should not inform them that it is something they can change or revert. We've had a case where a customer received this SL and did not have the permissions to do what we're asking. This updates the wording to remove that from the template.

Realistically this template shouldn't be used any more either assuming that the webhooks block the action, but it probably does not hurt to leave it around for now.