### PR TITLE
Add SL for proxy not reachable during installation

### DIFF
--- a/osd/aws/InstallFailed_proxy_unreachable.json
+++ b/osd/aws/InstallFailed_proxy_unreachable.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked: Missing route to internet",
+  "description": "Your cluster's installation is blocked because of the cluster-wide proxy configured is not reachable. Please review the network and proxy configuration before reattempting cluster installation process. - https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html",
+  "internal_only": false,
+  "event_stream_id": ""
+}


### PR DESCRIPTION
There's a case that the user configured a cluster wide proxy, but the route table in the subnet does not have a proper route to the proxy, thus blocking installation.