### PR TITLE
Improve blocked upgrade service log wording

### DIFF
--- a/osd/customer_alert_blocking_upgrade.json
+++ b/osd/customer_alert_blocking_upgrade.json
@@ -1,7 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
-    "summary": "Action required: Alert is blocking a cluster upgrade",
-    "description": "Your cluster requires you to take action because ${PROBLEM} is generating an alert, blocking a cluster upgrade. Without action, your cluster's SLA may be impacted.",
+    "summary": "Action required: Cluster Upgrade Blocked",
+    "description": "Your cluster requires you to take action because ${PROBLEM}. This is blocking your cluster from upgrading successfully. Please ${REQUIRED_CUSTOMER_ACTION} so that your cluster upgrade can proceed. Without action, your cluster's SLA may be impacted. Please refer to this documentation for more information: ${DOCUMENTATION}.",
     "internal_only": false
 }


### PR DESCRIPTION
Alerts are relevant to SREs but not to customers. In most cases they probably don't understand how they work. We should translate the alerts into simple text so that the customer can understand the issue, impact and has a clear ask about the action they need to perform to resolve their stuck upgrade. 

This PR, removes `alert` from the message/summary and adds parameters for `Customer Action` and `Documentation`.

(The name of the template should _probably_ change, but I couldn't come up with a better one, happy to change or keep it as is)