### PR TITLE
Remove "OpenShift Dedicated" from the messages that are common to both OSD and Rosa

### DIFF
--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -2,6 +2,6 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
-  "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift Dedicated version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342",
+  "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342",
   "internal_only": false
 }

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -2,7 +2,7 @@
  "severity": "Error",
  "service_name": "SREManualAction",
  "summary": "Action required: Elasticsearch impacted by cluster resource limits",
- "description": "Your cluster requires you to take action. Your OpenShift Dedicated cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/container-platform/latest/logging/config/cluster-logging-log-store.html#cluster-logging-logstore-limits_cluster-logging-store",
+ "description": "Your cluster requires you to take action. Your cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/container-platform/latest/logging/config/cluster-logging-log-store.html#cluster-logging-logstore-limits_cluster-logging-store",
  "internal_only": false
 }
 

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: update cluster configuration",
-    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in OpenShift Dedicated. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html",
+    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html",
     "internal_only": false
 }

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Resources overloaded",
- "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html",
+ "description": "Your cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html",
  "internal_only": false
 }

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Pod emptydir storage preventing Node Drain",
- "description": "Your OpenShift Dedicated cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/latest/storage/understanding-ephemeral-storage.html",
+ "description": "Your cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/latest/storage/understanding-ephemeral-storage.html",
  "internal_only": false
 }

--- a/osd/customer_pdb_preventing_drain.json
+++ b/osd/customer_pdb_preventing_drain.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Pod Disruption Budget preventing Node Drain",
- "description": "Your OpenShift Dedicated cluster is attempting to drain node `${NODE}` but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as `${POD}` running in the namespace: `${NAMESPACE}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring",
+ "description": "Your cluster is attempting to drain node `${NODE}` but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as `${POD}` running in the namespace: `${NAMESPACE}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring",
  "internal_only": false
 }

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -2,7 +2,7 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "summary": "Action required: Resources overloaded",
-    "description": "Your OpenShift Dedicated cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/latest/cicd/pipelines/reducing-pipelines-resource-consumption.html",
+    "description": "Your cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/latest/cicd/pipelines/reducing-pipelines-resource-consumption.html",
     "internal_only": false
    }
 

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Invalid TLS certificate",
-    "description" : "Your cluster uses an invalid TLS certificate. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains for OpenShift Dedicated at https://access.redhat.com/articles/5599621.",
+    "description" : "Your cluster uses an invalid TLS certificate. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
     "internal_only": false
 }

--- a/osd/silence_namespace_alerts_notice.json
+++ b/osd/silence_namespace_alerts_notice.json
@@ -2,6 +2,6 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "summary": "NOTICE: Silencing alerts for 'openshift-*' user namespaces",
-    "description": "The Red Hat SRE team monitors all OpenShift Dedicated namespaces matching pattern 'openshift-*'. This namespace prefix is reserved for infrastructure use. Red Hat SRE does not monitor user namespaces matching this pattern. Alerts for namespace '${NAMESPACE}' have been silenced and will not be re-enabled. Cluster metrics and alerts may still be accessed from the cluster console.",
+    "description": "The Red Hat SRE team monitors all namespaces matching pattern 'openshift-*' in the cluster. This namespace prefix is reserved for infrastructure use. Red Hat SRE does not monitor user namespaces matching this pattern. Alerts for namespace '${NAMESPACE}' have been silenced and will not be re-enabled. Cluster metrics and alerts may still be accessed from the cluster console.",
     "internal_only": false
 }

--- a/osd/unevictable_workload.json
+++ b/osd/unevictable_workload.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Unevictable workload detected",
- "description": "Your OpenShift Dedicated cluster is attempting to evict a pod from node ${NODE} but ${REASON} is blocking that. Please ensure that this issue is addressed in the configuration of your application. Otherwise, the ability to autoscale the cluster may be impacted.",
+ "description": "Your cluster is attempting to evict a pod from node ${NODE} but ${REASON} is blocking that. Please ensure that this issue is addressed in the configuration of your application. Otherwise, the ability to autoscale the cluster may be impacted.",
  "internal_only": false
 }

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -2,6 +2,6 @@
  "severity": "Warning",
  "service_name": "SREManualAction",
  "summary": "Action required: Unschedulable customer workload pod",
- "description": "Your OpenShift Dedicated cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html",
+ "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html",
  "internal_only": false
 }


### PR DESCRIPTION
There are a few templates here that specifically mention `OpenShift dedicated` when the message can be applicable to ROSA too. This PR is to generalise these templates so that they can be used for both product types.