### PR TITLE
Adding no_resources_to_run_userworkloadmonitoring.json

### DIFF
--- a/osd/no_resources_to_run_userworkloadmonitoring.json
+++ b/osd/no_resources_to_run_userworkloadmonitoring.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: User Workload Monitoring impacted by cluster resource limits",
+    "description" : "Your cluster requires you to take action. Your cluster's worker nodes do not have enough resources to run the cluster's User Workload Monitoring monitoring stack. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html",
+    "internal_only": false
+}


### PR DESCRIPTION
Adds a Service Log template to cover when a cluster's worker nodes have no resources available for UWM to properly run.