### PR TITLE
Adding customer_stopped_control_plane_node.json

### DIFF
--- a/osd/customer_stopped_control_plane_node.json
+++ b/osd/customer_stopped_control_plane_node.json
@@ -1,0 +1,7 @@
+{
+ "severity": "Warning",
+ "service_name": "SREManualAction",
+ "summary": "Action required: Restart control plane node",
+ "description": "Your cluster requires you to take action. Red Hat SRE have observed that a user `${USER}` has stopped one or more of your cluster's control plane instances: `${INSTANCE}`. Please note that stopping instances is not supported and may impact your cluster's SLA and ability to upgrade. Refer to the Responsibility Assignment guide for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html",
+ "internal_only": false
+}


### PR DESCRIPTION
Adding an SL template for when SRE detect that a cluster owner has deliberately stopped a control plane node. 