### PR TITLE
Make ClusterGoneMissing_FirewallIssue more generic

### DIFF
--- a/osd/NetworkMisconfiguration_WithDoc
+++ b/osd/NetworkMisconfiguration_WithDoc
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which are causing the following issue:${SYMPTOM} This may impact normal working of the cluster. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which are causing the following issue:${SYMPTOM} This may impact normal working of the cluster. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites",
     "internal_only": false
 }

--- a/osd/NetworkMisconfiguration_WithDoc
+++ b/osd/NetworkMisconfiguration_WithDoc
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which are causing the following issue:${SYMPTOM} This may impact normal working of the cluster. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites",
     "internal_only": false
 }

--- a/osd/aws/ClusterGoneMissing_FirewallIssue
+++ b/osd/aws/ClusterGoneMissing_FirewallIssue
@@ -1,8 +1,0 @@
-{
-  "severity": "Error",
-  "service_name": "SREManualAction",
-  "summary": "Action required: review firewall configuration",
-  "description": "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to the firewall configuration. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites.",
-  "internal_only": false,
-  "event_stream_id": ""
-}

--- a/osd/aws/ClusterGoneMissing_NetworkIssue
+++ b/osd/aws/ClusterGoneMissing_NetworkIssue
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: review firewall configuration",
+  "description": "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to ${REASON}. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites",
+  "internal_only": false,
+  "event_stream_id": ""
+}

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites",
+    "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites",
     "internal_only": false
 }


### PR DESCRIPTION
The pre-existing template would have been perfect for a situation where the cluster's cluster-wide-proxy was denying connections to DMS, except that it was firewall-centric in its wording.

This just lets the SRE put in a reason as a parameter rather than it being strictly a firewall problem.

Also the HTML link to the firewall prerequisites was fixed because the anchor seems to have been renamed lately. I took the opportunity to fix it in other locations where it was similarly busted.