### PR TITLE
Allow SRE to specify which egress URLs are blocked to the customer

### DIFF
--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to the internet-based resources which are required for the cluster operation and support. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
+    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
     "internal_only": false
 }


### PR DESCRIPTION
After SRE/osd-network-verifier has figured out which egress URLs are incorrectly blocked, it would be nice to tell the customer which URLs were misconfigured via SL instead of making the customer validate every requirement.