### PR TITLE
Fix broken responsibility assignment link

### DIFF
--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -2,6 +2,6 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "summary": "Non-Red Hat Access Core Secrets",
-    "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
+    "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html",
     "internal_only": false
 }

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -2,6 +2,6 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "summary": "Non-System Change SRE API Endpoint",
-    "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
+    "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html",
     "internal_only": false
 }

--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Platform component accessed by non-Red Hat SRE user",
-    "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment",
+    "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html",
     "internal_only": false
 }

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
-    "description" : "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://www.openshift.com/products/dedicated/responsibility-assignment.",
+    "description" : "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
     "internal_only": false
 }


### PR DESCRIPTION
https://www.openshift.com/products/dedicated/responsibility-assignment is dead. 

PTAL if this is the correct replacement link:
https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html