### PR TITLE
Expanding on unsupported_workload

### DIFF
--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Remove custom workload from control plane/infra nodes",
-    "description": "Your cluster requires you to take action because there is a custom workload scheduled on control plane/infra nodes. The control plane and infrastructure nodes are reserved for Red Hat workloads required to operate the service, as described in the Red Hat OpenShift Dedicated Service Definition. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html#compute_osd-service-definition.",
+    "description": "Your cluster requires you to take action because there is a custom workload scheduled on control plane/infra nodes: ${WORKLOAD}. The control plane and infrastructure nodes are reserved for Red Hat workloads required to operate the service, as described in the Red Hat OpenShift Dedicated Service Definition. Custom workloads can negatively impact the availability/supportability of control plane and infrastructure nodes. Please ensure this workload does not schedule to these nodes. For more information please refer to https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-compute_rosa-service-definition",
     "internal_only": false
 }


### PR DESCRIPTION
This is a minor update to the `unsupported_workload` template to prompt SRE to specify which workload is running on the control plane nodes, and to clearly indicate that this practice can result in stability issues for the control plane.
It also updates the Service Definition link to point to ROSA's as this is going to be the high likelihood product involved for this alert.