### PR TITLE
Adding customer_clusteroperator_down.json

### DIFF
--- a/osd/customer_clusteroperator_down.json
+++ b/osd/customer_clusteroperator_down.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: Remove or address failing cluster operator",
+    "description": "Your cluster requires you to take action because there is a custom ClusterOperator named '${NAME}' installed on the cluster, which is failing to reach an Available state. Unavailable or degraded ClusterOperators can prevent your cluster's ability to upgrade to future versions successfully. Please address or remove the ClusterOperator to allow your cluster to remain in an upgradeable state.",
+    "internal_only": false
+}


### PR DESCRIPTION
I observed a case where a customer installed an operator that installs itself as a `ClusterOperator`. The operator then had issues, which raises a `ClusterOperatorDown` alert which SRE cannot address. Adding this template to notify the customer and highlight them of potential issues.