### PR TITLE
Adding ROSA_AWS_KMS_permissions_required.json

### DIFF
--- a/osd/aws/ROSA_AWS_KMS_permissions_required.json
+++ b/osd/aws/ROSA_AWS_KMS_permissions_required.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to missing or insufficient privileges required by ROSA to access/use the customer-managed KMS key that has been supplied for encrypting instances. Please ensure that the appropriate IAM permissions are granted to the ManagedOpenShift roles to allow use of the key. For more information, please review the documentation: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations",
+    "internal_only": false
+}


### PR DESCRIPTION
An installation recently failed because the customer was using a custom KMS key but did not provide the correct permissions to the IAM Role, thus causing the control plane instances to not provision correctly at all. This template directs the customer to the documentation containing the missed steps.