### PR TITLE
Adding SL for product EOL date extensions

### DIFF
--- a/osd/eol_date_extended.json
+++ b/osd/eol_date_extended.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Info",
+    "service_name": "SREManualAction",
+    "summary": "Product end-of-life date extended",
+    "description": "The end-of-life cycle date for ${PRODUCT} is being extended to ${EOLDATE}. Please refer to our life cycle policy document for further information: ${DOCUMENTATION}",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR adds service log template `eol_date_extended.json`, which notifies cluster owners that `${PRODUCT}`'s EOL date has been extended to `${EOLDATE}` per docs link `${DOCUMENTATION}`.

This addresses [OSD-13610](https://issues.redhat.com/browse/OSD-13610), where OSD/ROSA v4.9's EOL date was extended. Some wording from that card has been modified slightly for clarity.