### PR TITLE
Limited support reqs "details" not "description"

### DIFF
--- a/osd/LimitedSupportCloud.json
+++ b/osd/LimitedSupportCloud.json
@@ -1,5 +1,5 @@
 {
     "summary": "Cluster is in Limited Support due to unsupported cloud provider configuration",
-    "description": "${CONFIGURATION}",
+    "details": "${CONFIGURATION}",
     "detection_type": "manual"
 }

--- a/osd/LimitedSupportCluster.json
+++ b/osd/LimitedSupportCluster.json
@@ -1,5 +1,5 @@
 {
     "summary": "Cluster is in Limited Support due to unsupported cluster configuration",
-    "description": "${CONFIGURATION}",
+    "details": "${CONFIGURATION}",
     "detection_type": "manual"
 }


### PR DESCRIPTION
Limited support's templates need a "details" field, not a Service Log "description" field.