### PR TITLE
Add notification when customer does not add required URLs to exclude from proxy re-encryption as per documentation

### DIFF
--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -1,0 +1,7 @@
+{
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Cluster-wide proxy network requirements not met",
+  "description": "Your cluster requires you to take action because the required URLs are not configured to be excluded from cluster-wide proxy re-encryption, resulting in cluster's monitoring stack not functioning correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
+  "internal_only": false
+ }


### PR DESCRIPTION
In [OSD-12147](https://issues.redhat.com/browse/OSD-12147) it was found that a few clusters had misconfigured proxy network requirements which was producing many low alerts. This service log was used to inform them about this. There have been other customer cases where we have found this to be the case too.