### PR TITLE
Updating the SL for invalid storage class to not request 'gp2' default

### DIFF
--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: Address storageclass configuration",
-    "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please restore 'gp2' as the cluster's default storage class by following the 'Storage Class Annotations' instructions in the OpenShift documentation: https://docs.openshift.com/container-platform/latest/post_installation_configuration/storage-configuration.html",
+    "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
     "internal_only": false
 }


### PR DESCRIPTION
With BYOK, gp2/gp3 doesn't require to be the cluster default storage class, but we still need a working default storageclass to be able to have a working monitoring stack so updating the SL accordingly. 