### PR TITLE
Adding pull_secret_rotated.json

### DIFF
--- a/osd/pull_secret_rotated.json
+++ b/osd/pull_secret_rotated.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Cluster pull secret updated",
+    "description": "The pull secret associated with account '${ACCOUNT}' has been rotated by Red Hat SRE in order to ensure that your cluster has successful connectivity to the Red Hat Registry and OpenShift Cluster Manager. Should you wish, you may download the updated copy of your pull secret from https://console.redhat.com/openshift/downloads#tool-pull-secret . This is an informational notice and no further action is required by you",
+    "internal_only": false
+}


### PR DESCRIPTION
This adds a template for when SRE has rotated an account's pull secret and the customer is being informed of the action.

This will accompany a SOP update to https://github.com/openshift/ops-sop/blob/master/v4/howto/rotate_pull_secret.md which will reference this template.

Non-goals, but something to look at in a future PR:
- Removing some of these other pull secret related templates, if they contradict or don't align with our current processes around pull secrets.