### PR TITLE
New ROSA AWS Permissions Issue Template

### DIFF
--- a/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster.  ${USER} is not authorized to perform ${REASON}. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html.",
+    "internal_only": false
+}


### PR DESCRIPTION
Adding template for ROSA AWS invalid permissions that allow the SRE to specify which user and what error.