### PR TITLE
Hint to failurePolicy configuration in the webhook SL

### DIFF
--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: review platform webhook configurations",
-    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade.",
+    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly, or alternatively set the impacted webhook's 'failurePolicy' setting to 'Ignore' to allow failed requests to be ignored. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html .",
     "internal_only": false
 }


### PR DESCRIPTION
Updates the 'failing webhook' Service Log to include product documentation and highlight that the cluster owner can modify the webhook to change its failurePolicy as a last resort to get things working.