### PR TITLE
Specify the user who accessed a platform component to avoid confusion

### DIFF
--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Platform component accessed by non-Red Hat SRE user",
-    "description": "A user on your system has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+    "description": "A user on your system, ${USER}, has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
     "internal_only": false
 }


### PR DESCRIPTION
After the customer received the notification in https://issues.redhat.com/browse/OHSS-18351, they believed it was Red Hat SRE that performed the action, not themselves