### PR TITLE
Custom servicelog to notify customers about OCPBUGS-6494 and failing 4.12 installs

### DIFF
--- a/osd/OCPBUGS6494_4_12_install_failure.json
+++ b/osd/OCPBUGS6494_4_12_install_failure.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked because of an installation bug described in https://issues.redhat.com/browse/OCPBUGS-6494. There is currently no way to reliably ensure an installation will succeed until the bug is resolved. Red Hat's recommendation is to install your cluster on 4.11 and upgrade to 4.12 once a path is available, or to continue to retry your install on 4.12.",
+    "internal_only": false
+}


### PR DESCRIPTION
Ref: https://redhat-internal.slack.com/archives/CCX9DB894/p1675282610828689?thread_ts=1675278560.056979&cid=CCX9DB894

This template can be removed when OCPBUGS-6494 is addressed