### PR TITLE
Cert signed by unknown authority SL

### DIFF
--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Invalid TLS certificate",
+    "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
+    "internal_only": false
+}


### PR DESCRIPTION
Template for cert error: 
`"https://console-openshift-console.apps.rdn01.exxonmobil.com/": x509: certificate signed by unknown authority`