### PR TITLE
remove the unused service log

### DIFF
--- a/osd/failed_to_pull_SCA.json
+++ b/osd/failed_to_pull_SCA.json
@@ -1,8 +1,0 @@
-{
-  "severity": "Error",
-  "service_name": "SREManualAction",
-  "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation is blocked because it failed to pull SCA certs. Please review and validate the following documentation to enable the installation to succeed: https://access.redhat.com/articles/simple-content-access where you can enable SCA.",
-  "internal_only": false,
-  "event_stream_id": ""
-}


### PR DESCRIPTION
Based on the recent discussion, the pull SCA failure during the installation should not block the installation.

Removing this template to reducing the confusion.

cc @boranx and @mjlshen to take a look