### PR TITLE
Adding a template for SL related to OCPBUGS-8038

### DIFF
--- a/osd/OCPBUG_install_failure.json
+++ b/osd/OCPBUG_install_failure.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked because of an installation bug described in ${OCPBUGS_LINK}. There is currently no way to reliably ensure an installation will succeed until the bug is resolved. Red Hat is working on resolving the issue. ${DETAILS} Please retry your cluster installation.",
+    "internal_only": false
+}


### PR DESCRIPTION
We're seeing CPD alerts related to the 4.12 installer race condition described in https://issues.redhat.com/browse/OCPBUGS-8038. We need a SL to notify the customers that they need to reprovision the cluster.

There's no details on the issue right now, or a workaround other than trying to create the cluster again.