### PR TITLE
Fix malformed JSON in osd/custom_domain_misconfiguration.json

### DIFF
--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: update custom domain configuration",
-    "description":  "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\.", \"apps2\", or \"default\". See documentation : https://access.redhat.com/articles/5599621",
+    "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
     "internal_only": false
 }


### PR DESCRIPTION
When trying to send a service log, I ran into this error. The error appeared to be a misplaced escape.

```
❯ osdctl servicelog post $CLUSTER_ID --dry-run --template 'https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/custom_domain_misconfiguration.json' --param CUSTOM_DOMAIN='example.com'
FATA[0000] Cannot not parse the JSON template.
Error: "invalid character '.' in string escape code" 
```