### PR TITLE
OSD-13047 add example tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ Using [osdctl](https://github.com/openshift/osdctl)
     ```
 
 Note: `Osdctl` supports the usage of the unique cluster name, or the internal- and external ID as clusterID.
+
+### Tags
+Some template files have a `_tag` field for easier searching.
+
+For example, in github, searching `t_network` will show you all the network related template files.

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Cluster ingress degraded",
-    "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Cluster ingress degraded",
+  "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Cluster ingress degraded",
+  "_tags": ["t_network"],
   "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Cluster ingress degraded",
   "_tags": ["t_network"],
+  "summary": "Cluster ingress degraded",
   "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",
   "internal_only": false
 }

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -3,5 +3,8 @@
   "service_name": "SREManualAction",
   "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
   "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342.",
-  "internal_only": false
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
   "_tags": ["t_network"],
+  "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
   "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342.",
   "internal_only": false
 }

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
+  "_tags": ["t_network"],
   "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Installation failed",
-    "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation failed",
+  "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Installation failed",
   "_tags": ["t_network", "t_config"],
+  "summary": "Installation failed",
   "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
   "internal_only": false
 }

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation failed",
+  "_tags": ["t_network", "t_config"],
   "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Multiple Default Storage Classes Configured",
   "_tags": ["t_config"],
+  "summary": "Action required: Multiple Default Storage Classes Configured",
   "description": "Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage.",
   "internal_only": false
 }

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Multiple Default Storage Classes Configured",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Multiple Default Storage Classes Configured",
-    "description": "Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Multiple Default Storage Classes Configured",
+  "description": "Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,7 +1,12 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Network misconfiguration",
+  "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}.",
+  "internal_only": false,
+  "_tags": [
+    "t_config",
+    "t_network",
+    "t_network"
+  ]
 }

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -2,11 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Network misconfiguration",
+  "_tags": ["t_config", "t_network"],
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}.",
-  "internal_only": false,
-  "_tags": [
-    "t_config",
-    "t_network",
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Network misconfiguration",
   "_tags": ["t_config", "t_network"],
+  "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}.",
   "internal_only": false
 }

--- a/osd/NetworkMisconfiguration_WithDoc
+++ b/osd/NetworkMisconfiguration_WithDoc
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Network misconfiguration",
-    "description":  "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Network misconfiguration",
+  "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/NetworkMisconfiguration_WithDoc.json
+++ b/osd/NetworkMisconfiguration_WithDoc.json
@@ -1,10 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "_tags": ["t_network"],
   "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Warning",
-    "service_name": "SREManualAction",
-    "summary": "Non-System Change SRE API Endpoint",
-    "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
-    "internal_only": false
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Non-System Change SRE API Endpoint",
+  "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -2,10 +2,7 @@
   "severity": "Warning",
   "service_name": "SREManualAction",
   "summary": "Non-System Change SRE API Endpoint",
+  "_tags": ["t_network", "t_config"],
   "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -1,8 +1,8 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
-  "summary": "Non-System Change SRE API Endpoint",
   "_tags": ["t_network", "t_config"],
+  "summary": "Non-System Change SRE API Endpoint",
   "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
   "internal_only": false
 }

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
   "_tags": ["t_config"],
+  "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
   "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance.",
   "internal_only": false
 }

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
-    "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
+  "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Remove or update pod security configuration",
-    "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Remove or update pod security configuration",
+  "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Remove or update pod security configuration",
+  "_tags": ["t_config"],
   "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Remove or update pod security configuration",
   "_tags": ["t_config"],
+  "summary": "Action required: Remove or update pod security configuration",
   "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051.",
   "internal_only": false
 }

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Adjust trusted build configuration",
   "_tags": ["t_config"],
+  "summary": "Action required: Adjust trusted build configuration",
   "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html. Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade.",
   "internal_only": false
 }

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Adjust trusted build configuration",
-    "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html. Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Adjust trusted build configuration",
+  "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html. Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Adjust trusted build configuration",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html. Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Address Security Context Constraint configuration",
   "_tags": ["t_config"],
+  "summary": "Action required: Address Security Context Constraint configuration",
   "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC.",
   "internal_only": false
 }

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Address Security Context Constraint configuration",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Address Security Context Constraint configuration",
-    "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Address Security Context Constraint configuration",
+  "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -1,8 +1,11 @@
 {
-    "severity": "Info",
-    "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Action required: Cluster proxy CA Expiring",
-    "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
-    "internal_only": false
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "cluster_uuid": "${CLUSTER_UUID}",
+  "summary": "Action required: Cluster proxy CA Expiring",
+  "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -2,8 +2,8 @@
   "severity": "Info",
   "service_name": "SREManualAction",
   "cluster_uuid": "${CLUSTER_UUID}",
-  "summary": "Action required: Cluster proxy CA Expiring",
   "_tags": ["t_network"],
+  "summary": "Action required: Cluster proxy CA Expiring",
   "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
   "internal_only": false
 }

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -3,9 +3,7 @@
   "service_name": "SREManualAction",
   "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Action required: Cluster proxy CA Expiring",
+  "_tags": ["t_network"],
   "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/cluster-wide_proxy_unreachable.json
+++ b/osd/cluster-wide_proxy_unreachable.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update cluster proxy state/configuration",
-    "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. If you require further assistance, please file a support request.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update cluster proxy state/configuration",
+  "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. If you require further assistance, please file a support request.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/cluster-wide_proxy_unreachable.json
+++ b/osd/cluster-wide_proxy_unreachable.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update cluster proxy state/configuration",
+  "_tags": ["t_network"],
   "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. If you require further assistance, please file a support request.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update cluster configuration",
+  "_tags": ["t_network"],
   "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update cluster configuration",
-    "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update cluster configuration",
+  "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update cluster configuration",
   "_tags": ["t_network"],
+  "summary": "Action required: update cluster configuration",
   "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html.",
   "internal_only": false
 }

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update cluster proxy configuration",
+  "_tags": ["t_network","t_config"],
   "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update cluster proxy configuration",
-    "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update cluster proxy configuration",
+  "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update cluster proxy configuration",
   "_tags": ["t_network","t_config"],
+  "summary": "Action required: update cluster proxy configuration",
   "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
   "internal_only": false
 }

--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update cluster proxy configuration",
+  "_tags": ["t_network"],
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update cluster proxy configuration",
   "_tags": ["t_network"],
+  "summary": "Action required: update cluster proxy configuration",
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
   "internal_only": false
 }

--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update cluster proxy configuration",
-    "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update cluster proxy configuration",
+  "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update cluster proxy configuration",
   "_tags": ["t_network"],
+  "summary": "Action required: update cluster proxy configuration",
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
   "internal_only": false
 }

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update cluster proxy configuration",
-    "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update cluster proxy configuration",
+  "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update cluster proxy configuration",
+  "_tags": ["t_network"],
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update custom domain configuration",
   "_tags": ["t_network", "t_config"],
+  "summary": "Action required: update custom domain configuration",
   "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
   "internal_only": false
 }

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update custom domain configuration",
+  "_tags": ["t_network", "t_config"],
   "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update custom domain configuration",
-    "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update custom domain configuration",
+  "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Unsupported change to worker node instances",
-    "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Unsupported change to worker node instances",
+  "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Unsupported change to worker node instances",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Unsupported change to worker node instances",
   "_tags": ["t_config"],
+  "summary": "Action required: Unsupported change to worker node instances",
   "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",
   "internal_only": false
 }

--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Revert modifications to default Security Context Contraints",
   "_tags": ["t_config"],
+  "summary": "Action required: Revert modifications to default Security Context Contraints",
   "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
   "internal_only": false
 }

--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Revert modifications to default Security Context Contraints",
+  "_tags": ["t_config"],
   "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Revert modifications to default Security Context Contraints",
-    "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Revert modifications to default Security Context Contraints",
+  "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: DNS misconfigration",
   "_tags": ["t_network", "t_config"],
+  "summary": "Action required: DNS misconfigration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impact normal working of the cluster. Please revert these changes.",
   "internal_only": false
 }

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: DNS misconfigration",
+  "_tags": ["t_network", "t_config"],
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impact normal working of the cluster. Please revert these changes.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: DNS misconfigration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impact normal working of the cluster. Please revert these changes.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: DNS misconfigration",
+  "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impact normal working of the cluster. Please revert these changes.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: update identity provider configuration",
+  "_tags": ["t_network", "t_config"],
   "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: update identity provider configuration",
-    "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: update identity provider configuration",
+  "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: update identity provider configuration",
   "_tags": ["t_network", "t_config"],
+  "summary": "Action required: update identity provider configuration",
   "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html.",
   "internal_only": false
 }

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Restore missing cloud credentials",
   "_tags": ["t_config"],
+  "summary": "Action required: Restore missing cloud credentials",
   "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
   "internal_only": false
 }

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Restore missing cloud credentials",
-    "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Restore missing cloud credentials",
+  "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Restore missing cloud credentials",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Fix AWS Role to maintain SRE support",
   "_tags": ["t_config"],
+  "summary": "Action required: Fix AWS Role to maintain SRE support",
   "description": "Your cluster requires you to take action because Red Hat OpenShift SRE are not able to access your AWS account due to ${REASON} in ${IAM_ROLE_NAME} IAM role that prevents SRE from supporting your cluster. Please fix the IAM role to maintain ongoing cluster support. If you intended to terminate this cluster then please delete the cluster.",
   "internal_only": false
 }

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Fix AWS Role to maintain SRE support",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because Red Hat OpenShift SRE are not able to access your AWS account due to ${REASON} in ${IAM_ROLE_NAME} IAM role that prevents SRE from supporting your cluster. Please fix the IAM role to maintain ongoing cluster support. If you intended to terminate this cluster then please delete the cluster.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -3,5 +3,8 @@
   "service_name": "SREManualAction",
   "summary": "Action required: Fix AWS Role to maintain SRE support",
   "description": "Your cluster requires you to take action because Red Hat OpenShift SRE are not able to access your AWS account due to ${REASON} in ${IAM_ROLE_NAME} IAM role that prevents SRE from supporting your cluster. Please fix the IAM role to maintain ongoing cluster support. If you intended to terminate this cluster then please delete the cluster.",
-  "internal_only": false
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
   "_tags": ["t_config"],
+  "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
   "description": "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
   "internal_only": false
 }

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
-    "description": "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
+  "description": "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
+  "_tags": ["t_config"],
   "description": "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -3,5 +3,9 @@
   "service_name": "SREManualAction",
   "summary": "Action required: Cluster-wide proxy network requirements not met",
   "description": "Your cluster requires you to take action because the required URLs are not configured to be excluded from cluster-wide proxy re-encryption, resulting in cluster's monitoring stack not functioning correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
-  "internal_only": false
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -2,10 +2,7 @@
   "severity": "Warning",
   "service_name": "SREManualAction",
   "summary": "Action required: Cluster-wide proxy network requirements not met",
+  "_tags": ["t_network", "t_config"],
   "description": "Your cluster requires you to take action because the required URLs are not configured to be excluded from cluster-wide proxy re-encryption, resulting in cluster's monitoring stack not functioning correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -1,8 +1,8 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
-  "summary": "Action required: Cluster-wide proxy network requirements not met",
   "_tags": ["t_network", "t_config"],
+  "summary": "Action required: Cluster-wide proxy network requirements not met",
   "description": "Your cluster requires you to take action because the required URLs are not configured to be excluded from cluster-wide proxy re-encryption, resulting in cluster's monitoring stack not functioning correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
   "internal_only": false
 }

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Review pull secret",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is either missing or is not associated with the cluster owner. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Review pull secret",
   "_tags": ["t_config"],
+  "summary": "Action required: Review pull secret",
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is either missing or is not associated with the cluster owner. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
   "internal_only": false
 }

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Review pull secret",
-    "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is either missing or is not associated with the cluster owner. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Review pull secret",
+  "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is either missing or is not associated with the cluster owner. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Review pull secret",
-    "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster. The user in the updated pull-secret doesn't match the cluster owner. Please fix the pull-secret, as the current configuration impacts Red Hat SRE's ability to monitor and operate your cluster, and your cluster's ability to initiate any upgrades.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Review pull secret",
+  "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster. The user in the updated pull-secret doesn't match the cluster owner. Please fix the pull-secret, as the current configuration impacts Red Hat SRE's ability to monitor and operate your cluster, and your cluster's ability to initiate any upgrades.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Review pull secret",
   "_tags": ["t_config"],
+  "summary": "Action required: Review pull secret",
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster. The user in the updated pull-secret doesn't match the cluster owner. Please fix the pull-secret, as the current configuration impacts Red Hat SRE's ability to monitor and operate your cluster, and your cluster's ability to initiate any upgrades.",
   "internal_only": false
 }

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Review pull secret",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster. The user in the updated pull-secret doesn't match the cluster owner. Please fix the pull-secret, as the current configuration impacts Red Hat SRE's ability to monitor and operate your cluster, and your cluster's ability to initiate any upgrades.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,7 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Network misconfiguration",
-    "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Network misconfiguration",
+  "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
+  "internal_only": false,
+  "_tags": [
+    "t_network",
+    "t_config"
+  ]
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -2,10 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Network misconfiguration",
+  "_tags": ["t_network", "t_config"],
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
-  "internal_only": false,
-  "_tags": [
-    "t_network",
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Network misconfiguration",
   "_tags": ["t_network", "t_config"],
+  "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
   "internal_only": false
 }

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Installation blocked, action required",
-    "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked, action required",
+  "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation blocked, action required",
+  "_tags": ["t_config"],
   "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Installation blocked, action required",
   "_tags": ["t_config"],
+  "summary": "Installation blocked, action required",
   "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs.",
   "internal_only": false
 }

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Invalid TLS certificate",
+  "_tags": ["t_network"],
   "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
-  "internal_only": false,
-  "_tags": [
-    "t_network"
-  ]
+  "internal_only": false
 }

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Invalid TLS certificate",
   "_tags": ["t_network"],
+  "summary": "Invalid TLS certificate",
   "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
   "internal_only": false
 }

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Invalid TLS certificate",
-    "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Invalid TLS certificate",
+  "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
+  "internal_only": false,
+  "_tags": [
+    "t_network"
+  ]
 }

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Cluster Degraded, action required",
+  "_tags": ["t_config"],
   "description": "Your cluster's health is degraded due a Service Control Policy (SCP) preventing administrator access in the AWS acction. Please review and validate the minimum requires SCP required on your AWS account to restore the cluster health. The minimum required SCP is described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-minimum-scp_prerequisites.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Cluster Degraded, action required",
   "_tags": ["t_config"],
+  "summary": "Cluster Degraded, action required",
   "description": "Your cluster's health is degraded due a Service Control Policy (SCP) preventing administrator access in the AWS acction. Please review and validate the minimum requires SCP required on your AWS account to restore the cluster health. The minimum required SCP is described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-minimum-scp_prerequisites.",
   "internal_only": false
 }

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Cluster Degraded, action required",
-    "description": "Your cluster's health is degraded due a Service Control Policy (SCP) preventing administrator access in the AWS acction. Please review and validate the minimum requires SCP required on your AWS account to restore the cluster health. The minimum required SCP is described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-minimum-scp_prerequisites.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Cluster Degraded, action required",
+  "description": "Your cluster's health is degraded due a Service Control Policy (SCP) preventing administrator access in the AWS acction. Please review and validate the minimum requires SCP required on your AWS account to restore the cluster health. The minimum required SCP is described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-minimum-scp_prerequisites.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: Address storageclass configuration",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: Address storageclass configuration",
   "_tags": ["t_config"],
+  "summary": "Action required: Address storageclass configuration",
   "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
   "internal_only": false
 }

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Address storageclass configuration",
-    "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Address storageclass configuration",
+  "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -2,9 +2,7 @@
   "severity": "Warning",
   "service_name": "SREManualAction",
   "summary": "Action required: Disable termination protection on cluster instances",
+  "_tags": ["t_config"],
   "description": "Your cluster is attempting to drain and replace worker node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Warning",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Disable termination protection on cluster instances",
-    "description": "Your cluster is attempting to drain and replace worker node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
-    "internal_only": false
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Disable termination protection on cluster instances",
+  "description": "Your cluster is attempting to drain and replace worker node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -2,9 +2,7 @@
   "severity": "Warning",
   "service_name": "SREManualAction",
   "summary": "Action required: Unschedulable customer workload pod",
+  "_tags": ["t_config"],
   "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Warning",
-    "service_name": "SREManualAction",
-    "summary": "Action required: Unschedulable customer workload pod",
-    "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html.",
-    "internal_only": false
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Action required: Unschedulable customer workload pod",
+  "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,8 +1,8 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
-  "summary": "Action required: Unschedulable customer workload pod",
   "_tags": ["t_config"],
+  "summary": "Action required: Unschedulable customer workload pod",
   "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html.",
   "internal_only": false
 }

--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -3,9 +3,7 @@
   "service_name": "SREManualAction",
   "cluster_uuid": "${CLUSTER_UUID}",
   "summary": "Action required: Misconfigured additional Trusted CA bundle",
+  "_tags": ["t_config"],
   "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }

--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -2,8 +2,8 @@
   "severity": "Info",
   "service_name": "SREManualAction",
   "cluster_uuid": "${CLUSTER_UUID}",
-  "summary": "Action required: Misconfigured additional Trusted CA bundle",
   "_tags": ["t_config"],
+  "summary": "Action required: Misconfigured additional Trusted CA bundle",
   "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html.",
   "internal_only": false
 }

--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -1,8 +1,11 @@
 {
-    "severity": "Info",
-    "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Action required: Misconfigured additional Trusted CA bundle",
-    "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html.",
-    "internal_only": false
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "cluster_uuid": "${CLUSTER_UUID}",
+  "summary": "Action required: Misconfigured additional Trusted CA bundle",
+  "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -1,7 +1,10 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "summary": "Action required: review user-workload-monitoring configuration",
-    "description": "Your cluster's user-workload-monitoring is misconfigured. ${REASON}. Please review your configuration according to ${DOCUMENTATION}.",
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Action required: review user-workload-monitoring configuration",
+  "description": "Your cluster's user-workload-monitoring is misconfigured. ${REASON}. Please review your configuration according to ${DOCUMENTATION}.",
+  "internal_only": false,
+  "_tags": [
+    "t_config"
+  ]
 }

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -1,8 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Action required: review user-workload-monitoring configuration",
   "_tags": ["t_config"],
+  "summary": "Action required: review user-workload-monitoring configuration",
   "description": "Your cluster's user-workload-monitoring is misconfigured. ${REASON}. Please review your configuration according to ${DOCUMENTATION}.",
   "internal_only": false
 }

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -2,9 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Action required: review user-workload-monitoring configuration",
+  "_tags": ["t_config"],
   "description": "Your cluster's user-workload-monitoring is misconfigured. ${REASON}. Please review your configuration according to ${DOCUMENTATION}.",
-  "internal_only": false,
-  "_tags": [
-    "t_config"
-  ]
+  "internal_only": false
 }


### PR DESCRIPTION
For easier github/local searching, we can add tags to the template files, so that it can be searched in multiple dimensions.

This PR adds the `t_network` and `t_config` tags for example. We can add more tags to the template files in the future. 