### PR TITLE
Add invalid GCP IAM creds template

### DIFF
--- a/osd/gcp/invalid_iaas_credentials.json
+++ b/osd/gcp/invalid_iaas_credentials.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Action required: Restore missing cloud credentials",
+    "description": "Your cluster requires you to take action because Red Hat SRE is not able to access the cloud provider infrastructure with the provided credentials in order to support your cluster. Please restore the credentials and permissions provided during install. For more information on the IAM roles and accesses required, please refer to the documentation available at: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html.",
+    "internal_only": false
+}


### PR DESCRIPTION
We don't seem to have a SL template for when GCP IAM has been broken.

This is a GCP-flavoured equivalent to the AWS one which points to the GCP docs.