### PR TITLE
Adds automated message with plurality

### DIFF
--- a/osd/customer_pdb_preventing_drain_automated.json
+++ b/osd/customer_pdb_preventing_drain_automated.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "summary": "Action required: Pod Disruption Budget(s) preventing Node Drain",
+    "description": "Your cluster is attempting to drain the node(s): `${NODELIST}` but there is a pod disruption budget set that is preventing the drain. The Managed OpenShift SRE team has identified the following workload(s) affected in namespace/pod-name format: "${PODLIST}". Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.",
+    "internal_only": false
+}


### PR DESCRIPTION
Adds an automated PDB drain message with plurality - to be used in conjunction with a new ops-sop script that gets affected pods out of the machine api controller logs.