### PR TITLE
Fix URL in rosa_second_monitoring_stack_installed.json

### DIFF
--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: remove second monitoring stack",
-    "description": "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.html.",
+    "description": "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/rosa-understanding-the-monitoring-stack.html.",
     "internal_only": false
 }


### PR DESCRIPTION
The docs URL in the 2nd monitoring stack SL returns a 404. This PR fixes the URL.