### PR TITLE
Add NODE_TYPE parameter to termination_protection template

### DIFF
--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -2,6 +2,6 @@
     "severity": "Warning",
     "service_name": "SREManualAction",
     "summary": "Action required: Disable termination protection on cluster instances",
-    "description": "Your cluster is attempting to drain and replace worker node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
+    "description": "Your cluster is attempting to drain and replace `${NODE_TYPE}` node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
     "internal_only": false
 }


### PR DESCRIPTION
Add a node_type parameter to this service log as it can be needed for master, infra or worker nodes.

It was already approved and used like this.
Short term reference: https://redhat-internal.slack.com/archives/CCX9DB894/p1683205963766669?thread_ts=1683185491.940869&cid=CCX9DB894 

Not sure about the parameter name :D happy for suggestions.
