### PR TITLE
[OSD-16249] - Add documentation link

### DIFF
--- a/osd/cluster-wide_proxy_unreachable.json
+++ b/osd/cluster-wide_proxy_unreachable.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: update cluster proxy state/configuration",
-    "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. If you require further assistance, please file a support request.",
+    "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. Please refer to the documentation for further information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
     "internal_only": false
 }


### PR DESCRIPTION
Replaces the "please file a support request" language with a link to the
cluster-wide proxy documentation, as cluster-wide proxy configuration
and maintenance is a customer responsibility.

REF: https://issues.redhat.com/browse/OSD-16249

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
