### PR TITLE
add no egress route SL for non-installing clusters

### DIFF
--- a/osd/rosa_no_egress_route.json
+++ b/osd/rosa_no_egress_route.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "_tags": ["t_network", "t_config"],
+  "summary": "Action required: Network misconfiguration",
+  "description": "Your cluster requires you to take action. SRE has observed that there is no egress route defined in your cluster's private subnet which impacts normal working of the cluster. Please refer to the rosa documentation on how to setup the route tables for private subnets: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#sample-vpc-architecture .",
+  "internal_only": false
+}


### PR DESCRIPTION
We seem to not have an SL for this case. the [existing SL](https://github.com/openshift/managed-notifications/blob/master/osd/required_network_egresses_are_blocked.json) for egress issues requires the specification of the URLS that aren't reachable, which doesn't really makes sense  when there's no egress at all.
So this is the non-install time SL equivalent for [this SL](https://github.com/openshift/managed-notifications/blob/master/osd/aws/InstallFailed_PrivateLink_subnetEgress.json).