### PR TITLE
OSD-17508 Add a variant of the infranode_resized template for automation

### DIFF
--- a/osd/infranode_resized_auto.json
+++ b/osd/infranode_resized_auto.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Info",
+    "_tags": ["t_config"],
+    "service_name": "SREManualAction",
+    "summary": "Infra nodes resized",
+    "description": "SRE has resized the infra nodes of your cluster to ${INSTANCE_TYPE} to accommodate cluster load.",
+    "internal_only": false
+}


### PR DESCRIPTION
This has fewer parameters so it can easily be sent as part of other tooling. The intended use case is that sending this service log will be automatic once `osdctl cluster resize infra` has completed