### PR TITLE
scc-validation webhook prevent user to modify default scc

### DIFF
--- a/osd/default_scc_modification.json
+++ b/osd/default_scc_modification.json
@@ -1,8 +1,0 @@
-{
-  "severity": "Error",
-  "service_name": "SREManualAction",
-  "_tags": ["t_config"],
-  "summary": "Action required: Revert modifications to default Security Context Contraints",
-  "description": "The cluster's default Security Context Constraints (SCC) have been modified, which can impact your cluster's SLA and ability to upgrade. Instead of modifying default SCC, it is recommended to create new SCC as described here: https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html.",
-  "internal_only": false
-}


### PR DESCRIPTION
This PR is for removing the "default_scc_modification" template because we have [scc-validation](https://github.com/openshift/managed-cluster-validating-webhooks/blob/a31473ce6cfef845a7b62422800372b03c35a289/docs/webhooks.json#L346C1-L366C5) in place to prevent user to modify default scc. 