### PR TITLE
Add HCP servicelog about OCPBUGS-14611

### DIFF
--- a/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
+++ b/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Cluster uninstall left behind PersistentVolume(s)",
+    "description": "The PersistentVolumeClaim(s) ${CLAIMS} with StorageClass ${STORAGECLASS} have been left behind after your ROSA HCP cluster's uninstall. It is safe to delete them if they are no longer needed for your workloads.",
+    "internal_only": false
+}


### PR DESCRIPTION
When OCPBUGS-14611 occurs, an uninstall leaves behind persistenvolumes that may cost the customer resources if they intended for them to be deleted.