### PR TITLE
Add SL for malformed cdo cert

### DIFF
--- a/osd/custom_domain_cert_misconfiguration.json
+++ b/osd/custom_domain_cert_misconfiguration.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "_tags": ["t_network", "t_config"],
+  "summary": "Action required: update custom domain configuration",
+  "description": "The custom application domain '${CUSTOM_DOMAIN}' has a malformed or misconfigured certificate. Please review the certificate provided by the '${SECRET}' secret in the '${SECRET_NS}' namespace to restore functionality to your cluster. For additional information on custom-domains-operator, refer to the following documentation: https://access.redhat.com/articles/5599621.",
+  "internal_only": false
+}


### PR DESCRIPTION
Adds template for cases where a `customdomain`'s certificate is malformed or misconfigured