### PR TITLE
Added SL for CPDs due to bad DHCP Optionsets

### DIFF
--- a/osd/aws/InstallFailed_InvalidDHCPOptionset.json
+++ b/osd/aws/InstallFailed_InvalidDHCPOptionset.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation was blocked by a misconfigured DHCP option set attached to your target VPC. DHCP option set ${OPTIONSET_ID} contains one or more spaces or capital letters in its `Domain name` field, which are not allowed by the DHCP protocol (see RFC 2132 section 3.17). Please remove all spaces and capital letters from the `Domain name` field and try re-installing the cluster.",
+  "_tags": ["t_install", "t_network"],
+  "internal_only": false
+}


### PR DESCRIPTION
Occasionally, we'll get a CPD triggered by a customer's use of illegal characters (spaces and capital letters) in their DHCP optionset. This PR adds the SL I sent [last time](https://redhat-internal.slack.com/archives/CCX9DB894/p1692738819460279) I ran into this, which has already been [approved](https://redhat-internal.slack.com/archives/CCX9DB894/p1692739260620989?thread_ts=1692738819.460279&cid=CCX9DB894) by a manager.