### PR TITLE
add service log encouraging customers to upgrade to fix OCPBUGS-16655

### DIFF
--- a/OCPBUGS-16655-remediation-please-upgrade.json
+++ b/OCPBUGS-16655-remediation-please-upgrade.json
@@ -1,0 +1,7 @@
+{
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Cluster impacted by OCPBUGS-16655, upgrade recommended",
+  "description": "Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655, which results in nodes periodically being unable to run containers. Red Hat SRE has responded to and temporarily remediated impacts of this bug on this cluster and recommends that the cluster be upgraded to 4.13.10 or later as soon as convenient.",
+  "internal_only": false
+}


### PR DESCRIPTION
The goals of this SL are for SRE to:

* notify the customer that SRE has manually remediated the impacts of OCPBUGS-16655 on their cluster, however we can't stop it from happening again.
* the real fix is for the cluster to be upgraded to 4.13.10+

[OSD-18461](https://issues.redhat.com//browse/OSD-18461)