### PR TITLE
Updated SL for 2nd monitoring stack with correct links

### DIFF
--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: remove second monitoring stack",
-    "description": "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/rosa-understanding-the-monitoring-stack.html.",
+    "description": "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/monitoring-overview.html#understanding-the-monitoring-stack_monitoring-overview.",
     "internal_only": false
 }


### PR DESCRIPTION
The SL for the 2nd monitoring stack for ROSA has an [outdated link](https://docs.openshift.com/rosa/monitoring/rosa-understanding-the-monitoring-stack.html) for documentation for CU 

This updates the link to the [working link ](https://docs.openshift.com/rosa/monitoring/monitoring-overview.html#understanding-the-monitoring-stack_monitoring-overview)