### PR TITLE
Remove failurePolicy suggestion from "bad webhook" SL

### DIFF
--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: review platform webhook configurations",
-    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html",
+    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html.",
     "internal_only": false
 }

--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Action required: review platform webhook configurations",
-    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly, or alternatively set the impacted webhook's 'failurePolicy' setting to 'Ignore' to allow failed requests to be ignored. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html .",
+    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html",
     "internal_only": false
 }


### PR DESCRIPTION
This PR removes a service log's suggestion that the customer use the 'failurePolicy' setting to mitigate a custom webhook that's misbehaving. While the original PR that added this suggestion surely had good intentions, a recent [thread](https://redhat-internal.slack.com/archives/CCX9DB894/p1698698084152229?thread_ts=1698697348.382599&cid=CCX9DB894) shows that a customer may use this setting to mask such an issue just enough to get out of limited support (as opposed to actually fixing the broken webhook). 

The linked OCP docs also discourage this suggestion: "Using `Ignore` can result in unpredictable behavior for all clients."