### PR TITLE
Create InstallFailed_InvalidCustomTag.json

### DIFF
--- a/osd/aws/InstallFailed_InvalidCustomTag.json
+++ b/osd/aws/InstallFailed_InvalidCustomTag.json
@@ -1,0 +1,11 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation is blocked due to an invalid user-defined tag. The tag provided for the cluster install with the key '${KEY}' is not allowed. Please change or remove the invalid tag and try re-installing the cluster.",
+  "internal_only": false,
+  "_tags": [
+    "t_install",
+    "sop_ClusterProvisioningFailure"
+  ]
+}


### PR DESCRIPTION
Ran into a ClusterProvisioningDelay caused by a bad user-defined custom tag today. While this should be addressed by [OCM-1554](https://issues.redhat.com/browse/OCM-1554), I think this SL could be helpful while we wait for that fix. Wording is based on [this Slack post](https://redhat-internal.slack.com/archives/CCX9DB894/p1680358346002239?thread_ts=1680358021.496339&cid=CCX9DB894).