### PR TITLE
OSD-19762: Adding attributes to managed-notifications

### DIFF
--- a/osd/AddonMisconfiguration.json
+++ b/osd/AddonMisconfiguration.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-add-ons",
   "_tags": ["t_config"],
   "summary": "Action required: Add-on misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that an add-on, ${ADDON}, is misconfigured which could impact normal working of the cluster. Please refer to the documentation ${DOC}.",

--- a/osd/AlertmanagerSilencesActiveSRE.json
+++ b/osd/AlertmanagerSilencesActiveSRE.json
@@ -1,8 +1,10 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "AlertManager Silences Identified",
   "description": "Cluster has been identified with AlertManager silences. Silences prevent Red Hat from effectively monitoring this cluster and will be removed.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/managing-pod-security-policies#scc-prioritization_configuring-internal-oauth"],
   "internal_only": false,
   "_tags": [
     "sop_AlertmanagerSilencesActiveSRE"

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Bad MachineConfigPool Configuration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made to the cluster MachineConfigPool. ${REASON}. Please revert these changes or consult the documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html for details.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#rosa-managing-worker-nodes"],
     "internal_only": false
 }

--- a/osd/BadMachinePoolTaint.json
+++ b/osd/BadMachinePoolTaint.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Incorrect MachinePool Configuration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made to one of the cluster MachinePools. This prevents changes made to taints or labels to be propagated to nodes, which can impact scheduling of your workloads. ${REASON}. Please revert these changes.",
     "internal_only": false

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network"],
   "summary": "Cluster ingress degraded",
   "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "_tags": ["t_network"],
   "summary": "Installation failed: Your cluster's CIDR ranges overlap with the default Docker Bridge subnet",
   "description": "Your cluster's installation has failed due to an overlap with the default Docker Bridge subnet, 172.17.0.0/16. This failure is only present on 4.5 cluster installs. Please install a new cluster on a supported OpenShift version (https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle). For more details, see https://bugzilla.redhat.com/show_bug.cgi?id=1858342.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-life-cycle"],
   "internal_only": false
 }

--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: review cluster logging configuration",
     "description": "Your cluster's ElasticSearch deployment is misconfigured in a way that is impacting its operation. ${REASON} For more information, please consult the following documentation reference: https://docs.openshift.com/container-platform/latest/logging/cluster-logging.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/troubleshooting-logging"],
     "internal_only": false
 }

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: Elasticsearch impacted by cluster resource limits",
     "description": "Your cluster requires you to take action. Your cluster does not have enough resources to run Elasticsearch. Please refer to the following documentation for detailed instructions: https://docs.openshift.com/container-platform/latest/logging/config/cluster-logging-log-store.html#cluster-logging-logstore-limits_cluster-logging-store.",
     "internal_only": false

--- a/osd/ElasticsearchClusterNotHealthy_Error.json
+++ b/osd/ElasticsearchClusterNotHealthy_Error.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",
     "summary": "Urgent action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch storage is greater than 95% utilized, and data loss is imminent. Red Hat SRE strongly recommends reducing application logging on your cluster to ensure logging continues to function.",

--- a/osd/ElasticsearchClusterNotHealthy_Warning.json
+++ b/osd/ElasticsearchClusterNotHealthy_Warning.json
@@ -1,8 +1,10 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",
     "summary": "Action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch storage is greater than 85% utilized. If this goes above 95%, data might will be lost. SRE will increase capacity one time causing a period while Elasticsearch is unavailable. Old logs will be retained. Logs for pods deleted while migration is in progress may be lost. SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/cluster-logging-deploying#configuring-log-storage-cr_cluster-logging-deploying"],
     "internal_only": false
 }

--- a/osd/Failed_Logins.json
+++ b/osd/Failed_Logins.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-security",
   "summary": "There are an elevated number of failed logins on your cluster",
   "description": "The Red Hat Site Reliability Engineering (SRE) team detected a security event on your Managed OpenShift cluster. There are an elevated number of failed logins on your cluster(s) from user ${USERNAME}. Red Hat SRE is sending this notice to you for further analysis. Please review OpenShift Authentication for configuration information https://docs.openshift.com/container-platform/latest/authentication/understanding-authentication.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/overview-of-authentication-authorization#authentication-overview"],
   "internal_only": false,
   "_tags": [
     "sop_SplunkFailedLogins"

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "_tags": ["t_network", "t_config"],
   "summary": "Installation failed",
   "description": "Your cluster's installation has failed related to an invalid CIDR configuration. The Machine CIDR range is invalid and causing an error 'The subnet's CIDR range start 10.1.100.0 is outside of the specified machine networks'. You must delete this cluster, and recreate it with a larger Machine CIDR that includes all of the subnets CIDR ranges.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/cidr-range-definitions"],
   "internal_only": false
 }

--- a/osd/KubePersistentVolumeFillingUpError-user.json
+++ b/osd/KubePersistentVolumeFillingUpError-user.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: Persistent Volume filling",
     "description": "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp' in '${NAMESPACE}'. This is not an actionable alert for the SRE team. Please address this PV capacity issue using this reference documentation: https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html.",
+    "doc_references": ["https://docs.openshift.com/container-platform/4.14/storage/expanding-persistent-volumes.html"],
     "internal_only": false
 }

--- a/osd/KubePersistentVolumeFillingUpError.json
+++ b/osd/KubePersistentVolumeFillingUpError.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Urgent action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch is at ${PERCENT}% load. Red Hat SRE strongly recommends immediately reducing application logging on your cluster to ensure logging continues to function in the near future. If logging stack stops functioning the logging stack will need reprovisioned to recover and application logs will be lost.",
     "internal_only": false

--- a/osd/KubePersistentVolumeFillingUpWarn.json
+++ b/osd/KubePersistentVolumeFillingUpWarn.json
@@ -1,6 +1,7 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: update cluster logging configuration",
     "description": "Your cluster requires you to take action. Elasticsearch is on average at ${PERCENT}% load. If this goes above 95%, data might will be lost. SRE will increase capacity one time causing a period while Elasticsearch is unavailable. Old logs will be retained. Logs for pods deleted while migration is in progress may be lost. SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",
     "internal_only": false

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Multiple Default Storage Classes Configured",
   "description": "Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage.",
   "internal_only": false,

--- a/osd/Multiple_OCPBUGs_install_failure.json
+++ b/osd/Multiple_OCPBUGs_install_failure.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked because of known installation bugs affecting the selected OpenShift version (${OCPBUGS_LINKS}). There is currently no way to reliably ensure an installation will succeed until these bugs are resolved. Red Hat is working on resolving the issue. Please retry your cluster installation or select a different OpenShift version.",
     "internal_only": false

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_config", "t_network"],
   "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}.",

--- a/osd/NetworkMisconfiguration_WithDoc.json
+++ b/osd/NetworkMisconfiguration_WithDoc.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network"],
   "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to network configuration which impact normal working of the cluster: ${CHANGE}. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",

--- a/osd/NodeFileDescriptorLimit_worker.json
+++ b/osd/NodeFileDescriptorLimit_worker.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "capacity-management",
   "summary": "Action required: Worker node file descriptor limit nearly exhausted",
   "description": "Your cluster requires you to take action. The kernel file descriptor limit for worker node ${NODE} is currently at or above 90% and is predicted to be fully exhausted soon. This will prevent applications on the node from opening and operating on files. Without action, your cluster's SLA and ability to upgrade may be impacted. Please reduce the number of simultaneously-open files on this node, either by adjusting application configuration or by moving some applications to other nodes.",
   "internal_only": false,

--- a/osd/NodeFilesystemSpaceFillingUp-worker.json
+++ b/osd/NodeFilesystemSpaceFillingUp-worker.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "capacity-management",
   "summary": "Action required: Worker node mountpoint space nearly exhausted",
   "description": "Your cluster requires you to take action. The '${MOUNTPOINT}' file system usage for worker node ${NODE} is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of space used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.",
   "internal_only": false,

--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-security",
   "summary": "Non-Red Hat Access Core Secrets",
   "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
   "internal_only": false,
   "_tags": [
     "sop_SplunkNonRedHatAccessCoreSecrets"

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Non-System Change SRE API Endpoint",
   "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "OCM3018 Installation blocked, action required",
     "description": "Your ROSA STS cluster installation is blocked due to a problem with one of the STS roles used to provision the cluster. No worker nodes could be created. Verify that the trusted entity in your \"openshift-machine-api-aws-cloud-credentials\" role references the correct cluster id, ${CLUSTER_OCM_ID}, and try again. See https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html for more information.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],
     "internal_only": false
 }

--- a/osd/OCPBUGS-16655-remediation-please-upgrade.json
+++ b/osd/OCPBUGS-16655-remediation-please-upgrade.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-updates",
   "summary": "Cluster impacted by OCPBUGS-16655, upgrade recommended",
   "description": "Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655, which results in nodes periodically being unable to run containers. Red Hat SRE has responded to and temporarily remediated impacts of this bug on this cluster and recommends that the cluster be upgraded to 4.13.10 or later as soon as convenient.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/rosa-upgrading-sts"],
   "internal_only": false,
   "_tags": [
     "sop_PruningCronjobErrorSRE"

--- a/osd/OCPBUGS6494_4_12_install_failure.json
+++ b/osd/OCPBUGS6494_4_12_install_failure.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked because of an installation bug described in https://issues.redhat.com/browse/OCPBUGS-6494. There is currently no way to reliably ensure an installation will succeed until the bug is resolved. Red Hat's recommendation is to install your cluster on 4.11 and upgrade to 4.12 once a path is available, or to continue to retry your install on 4.12.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/rosa-upgrading-sts"],
     "internal_only": false
 }

--- a/osd/OCPBUG_install_failure.json
+++ b/osd/OCPBUG_install_failure.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked because of an installation bug described in ${OCPBUGS_LINK}. There is currently no way to reliably ensure an installation will succeed until the bug is resolved. Red Hat is working on resolving the issue. ${DETAILS} Please retry your cluster installation.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/index"],
     "internal_only": false
 }

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-add-ons",
   "_tags": ["t_config"],
   "summary": "Action required: ${OPERATOR_NAME} is misconfigured",
   "description": "Your cluster requires you to take action. Installed operator ${OPERATOR_NAME} is failing due to ${REASON}. Please consult the relevant documentation for further assistance.",

--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Platform component accessed by non-Red Hat SRE user",
   "description": "A user on your system, ${USER}, has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
   "internal_only": false,
   "_tags": [
     "sop_SplunkNonRedHatAccessCoreSecrets",

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: Remove or update pod security configuration",
   "description": "Your cluster has a Pod Security Policy installed which is impacting the operation of Red Hat cluster workloads. Please review or remove the Pod Security Policies which have been installed. For more information on Pod Security Policy support in OpenShift, please refer to https://access.redhat.com/solutions/5622051.",

--- a/osd/RHOAMInstallNeedsMoreResources.json
+++ b/osd/RHOAMInstallNeedsMoreResources.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-add-ons",
   "summary": "Action required: Add resources to complete RHOAM installation",
   "description": "Your cluster does not have sufficient resources to install the Red Hat OpenShift API Management add-on. Please reference https://access.redhat.com/articles/5534341 and provide the necessary resources to complete the installation.",
+  "doc_references": ["https://access.redhat.com/articles/5534341#resource-requirements-16"],
   "internal_only": false,
   "event_stream_id": "${JIRA_ID}",
   "_tags": [

--- a/osd/RecoveryOfDeletedMaster.json
+++ b/osd/RecoveryOfDeletedMaster.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Recovery of deleted master nodes is not supported",
     "description": "SRE have noticed that one or more master nodes have been terminated manually. Please note that recovery of terminated master nodes is not possible in some cases. Changing the running state of one of the master nodes manually will result in loss of cluster functionality and impact your cluster's SLAs. SRE suggests that you reinstall the cluster to return it to the desired state. If you require further assistance, please file a support request.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations"],
     "internal_only": false
 }

--- a/osd/ResourceIsRaisingClusterAlert.json
+++ b/osd/ResourceIsRaisingClusterAlert.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is triggering a alert",
     "description": "Your cluster requires you to take action. The resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is causing the alert ${ALERTNAME} to fire. Please ${ACTION_REQUIRED} in order to return the cluster back to normal operations.",
     "internal_only": false

--- a/osd/ResourceQuotaOpenshiftNamespace.json
+++ b/osd/ResourceQuotaOpenshiftNamespace.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Installed ServiceQuotas in openshift namespaces breaks cluster operation",
   "description": "Your cluster requires you to take action because an installed ServiceQuota '${SERVICEQUOTA}', is preventing cluster workloads from running. Please remove the quota from all openshift namespaces. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/container-platform/4.10/applications/quotas/quotas-setting-per-project.html.",
+  "doc_references": ["https://docs.openshift.com/container-platform/4.14/applications/quotas/quotas-setting-per-project.html"],
   "internal_only": false,
   "_tags": [
     "sop_PruningCronjobErrorSRE"

--- a/osd/ReviewServiceControlPolicy.json
+++ b/osd/ReviewServiceControlPolicy.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Action required: Review Service Control Policy",
     "description": "Your cluster requires you to take action because the '${CREDENTIAL_REQUEST}' credential request is failing to renew. This may be due to a Service Control Policy (SCP) applied at the AWS Organization level. This is currently impacting your cluster's ability to upgrade, and without action, your cluster's SLA may be impacted. Please refer to this documentation for more information:  https://access.redhat.com/solutions/5795441.",
+    "doc_references": ["https://access.redhat.com/solutions/5795441"],
     "internal_only": false
 }

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation failed (invalid IAM roles)",
     "description": "Your cluster's installation has failed related to an invalid IAM roles. You must delete this cluster, and recreate it with valid iam roles, see reference in https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#rosa-policy-iam_prerequisites.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-ocm-role"],
     "internal_only": false
 }

--- a/osd/StuckNewBuilds3MinSRE.json
+++ b/osd/StuckNewBuilds3MinSRE.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: update cluster build configuration",
   "description": "Your cluster requires you to take action. Container image builds are failing and must be resolved. Please check the image build error logs and update your configuration. For more information refer to https://docs.openshift.com/container-platform/latest/cicd/builds/understanding-image-builds.html.",
+  "doc_references": ["https://docs.openshift.com/container-platform/4.14/cicd/builds/basic-build-operations.html#builds-basic-access-build-logs_basic-build-operations"],
   "internal_only": false,
   "_tags": [
     "sop_StuckNewBuilds3MinSRE"

--- a/osd/User_Forbidden.json
+++ b/osd/User_Forbidden.json
@@ -1,6 +1,7 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-security",
   "summary": "Elevated rate of failed authorization events on your Managed OpenShift cluster",
   "description": "The Red Hat Site Reliability Engineering (SRE) team detected a security event on your Managed OpenShift cluster. There are an elevated number of API calls that failed authorization for the following users on your cluster: ${USERNAME}. Because the users belong to your organization, Red Hat SRE is sending this notice to you for further analysis.",
   "internal_only": false,

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -1,6 +1,8 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cicd/builds#setting-up-trusted-ca"],
   "_tags": ["t_config"],
   "summary": "Action required: Adjust trusted build configuration",
   "description": "Your cluster requires you to take action because the cluster's image registry is in a degraded state due to a misconfiguration. A trusted CA ConfigMap has been added to the 'cluster' images.config.openshift.io resource's 'additionalTrustedCA' section, but the corresponding ConfigMap does not exist in the openshift-config namespace. Please create that ConfigMap by following the product documentation: https://docs.openshift.com/container-platform/latest/cicd/builds/setting-up-trusted-ca.html. Without action, the image registry will remain in a degraded state and will impact the cluster's ability to upgrade.",

--- a/osd/aws/AWS_outage.json
+++ b/osd/aws/AWS_outage.json
@@ -1,7 +1,9 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "AWS Outage Impacting Your Cluster",
     "description": "Red Hat has identified an AWS issue that may impact your cluster. For more details, including incident resolution, see https://health.aws.amazon.com/.",
+    "doc_references": ["https://docs.aws.amazon.com/health/latest/ug/first-time-user.html"],
     "internal_only": false
 }

--- a/osd/aws/AWS_zone_outage.json
+++ b/osd/aws/AWS_zone_outage.json
@@ -1,8 +1,10 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "AWS Availability Zone Outage Impacting Your Cluster",
     "description": "Red Hat has identified an outage in ${ZONE} that is affecting your cluster. For more details, including incident resolution, see https://health.aws.amazon.com/.",
     "_tags": ["t_outage"],
+    "doc_references": ["https://docs.aws.amazon.com/health/latest/ug/first-time-user.html"],
     "internal_only": false
 }

--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on AWS AddressLimitExceeded error. Please raise the EIP addresses quota or remove some EIP addresses for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_referneces": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/managing-alerts#expiring-silences_managing-alerts"],
     "internal_only": false
 }

--- a/osd/aws/AlertmanagerSilencesActiveSRE.json
+++ b/osd/aws/AlertmanagerSilencesActiveSRE.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Clear Alertmanager Silences",
     "description": "Your cluster's monitoring stack has silenced alerts. This prevents Red Hat SRE from monitoring this cluster. Please clear alert silences immediately.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/managing-alerts#expiring-silences_managing-alerts"],
     "internal_only": false
 }

--- a/osd/aws/ClusterGoneMissing_NetworkIssue
+++ b/osd/aws/ClusterGoneMissing_NetworkIssue
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: review firewall configuration",
   "description":  "Your cluster is failing to check in to our monitoring system since ${TIME}. Further investigation shows that the cluster is up and running but the VPC is unable to reach the essential domain/s `${ENDPOINTS}`. We believe the issue is occurring due to ${REASON}. Please review any recent configuration changes and ensure that the allowlist needs are satisfied per this documentation https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",
   "internal_only": false,

--- a/osd/aws/ELBDeleted.json
+++ b/osd/aws/ELBDeleted.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-networking",
     "summary": "Cluster Operators degraded",
     "description": "The cluster ingress operator for your cluster is currently degraded due to the deletion of an AWS Elastic Load Balancer used by OpenShift. This may cause instability in the service and may impact the supportability of your cluster. Please work with Red Hat support to help remediate this issue.",
     "internal_only": false

--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: review account quota",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/aws/GenericResourceDeleted.json
+++ b/osd/aws/GenericResourceDeleted.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Critical AWS Resource Has Been Deleted",
     "description": "SRE has found that a critical AWS resource has been deleted, which may impact the supportability of your cluster. ${REASON} Please work with Red Hat support to help remediate this issue.",
     "internal_only": false

--- a/osd/aws/InstallFailed_AWSS3Change.json
+++ b/osd/aws/InstallFailed_AWSS3Change.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",
     "description": "ROSA and OSD installations on AWS may fail due a recently changed AWS security policy. Red Hat is investigating the issue and updates will be posted to this KCS: https://access.redhat.com/solutions/7007136.",
+    "doc_references": ["https://access.redhat.com/solutions/7007136"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_AWS_Capacity.json
+++ b/osd/aws/InstallFailed_AWS_Capacity.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on an AWS datacenter capacity issue. AWS does not have capacity for ${INSTANCE_TYPE} in ${REGION} at the moment. Please retry installation in another region or select a different instance type.",
     "internal_only": false

--- a/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
+++ b/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS error: 'Error creating S3 bucket: SlowDown: Please reduce your request rate.' The S3 bucket request rate will need to be lowered to within AWS request limits in order for the installaiton to succeed. AWS S3 request limits are described in this document - https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/.",
+    "doc_references": ["https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_CreateServiceLinkedRole.json
+++ b/osd/aws/InstallFailed_CreateServiceLinkedRole.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked because the ELB Service Role does not exist. In AWS accounts that have never created a load balancer before, it is possible that the service role for ELB might not exist yet. Please refer to the troubleshooting doc: 'https://docs.openshift.com/rosa/rosa_support/rosa-troubleshooting-deployments.html#rosa-troubleshooting-elb-serivce-role_rosa-troubleshooting-cluster-deployments'.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-troubleshooting-cluster-deployments#rosa-troubleshooting-elb-service-role_rosa-troubleshooting-cluster-deployments"],
   "internal_only": false
 }

--- a/osd/aws/InstallFailed_InsufficientPermissions.json
+++ b/osd/aws/InstallFailed_InsufficientPermissions.json
@@ -1,8 +1,10 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is delayed and Red Hat SRE is unable to support, troubleshoot and resolve issues because ManagedOpenShift-Support-Role has insufficient permissions. Without action taken to fix the permissions, your cluster's SLA may be impacted, along with your ability to access the cluster. Please refer to this documentation for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-ocm-role"],
     "internal_only": false,
     "event_stream_id": ""
 }

--- a/osd/aws/InstallFailed_InvalidCustomTag.json
+++ b/osd/aws/InstallFailed_InvalidCustomTag.json
@@ -1,11 +1,13 @@
 {
-  "severity": "Error",
-  "service_name": "SREManualAction",
-  "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation is blocked due to an invalid user-defined tag. The tag provided for the cluster install with the key '${KEY}' is not allowed. Please change or remove the invalid tag and try re-installing the cluster.",
-  "internal_only": false,
-  "_tags": [
-    "t_install",
-    "sop_ClusterProvisioningFailure"
-  ]
-}
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "log_type" : "cluster-lifecycle",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to an invalid user-defined tag. The tag provided for the cluster install with the key '${KEY}' is not allowed. Please change or remove the invalid tag and try re-installing the cluster.",
+    "internal_only": false,
+    "_tags": [
+      "t_install",
+      "sop_ClusterProvisioningFailure"
+    ]
+  }
+

--- a/osd/aws/InstallFailed_InvalidDHCPOptionset.json
+++ b/osd/aws/InstallFailed_InvalidDHCPOptionset.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked by a misconfigured DHCP option set attached to your target VPC. DHCP option set ${OPTIONSET_ID} contains one or more spaces or capital letters in its `Domain name` field, which are not allowed by the DHCP protocol (see RFC 2132 section 3.17). Please remove all spaces and capital letters from the `Domain name` field and try re-installing the cluster.",
   "internal_only": false,

--- a/osd/aws/InstallFailed_InvalidSubnet.json
+++ b/osd/aws/InstallFailed_InvalidSubnet.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations.",
   "internal_only": false

--- a/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
+++ b/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Duplicate hosted zones",
   "description": "Your cluster's installation is blocked because a duplicate Route53 HostedZone already exists in your account named '${ZONE_NAME}', ID '${ZONE_ID}'. If this hosted zone is no longer required, it can be removed and an installation re-attempted.",
   "internal_only": false,

--- a/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
+++ b/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Inspection of the configuration showed one or more NAT gateways are located in private subnets, but they should be located in public subnets. Please review the network configuration, and try re-installing the cluster. AWS VPC requirements are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#rosa-vpc_rosa-sts-aws-prereqs"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_NetworkMisconfigured.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Please review the network configuration, and try re-installing the cluster. AWS VPC requirements are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html.",
+    "doc_references":["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-aws-privatelink-creating-cluster#doc-wrapper"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. ${DETAILS} ${DOCSURL} Try re-installing the cluster after addressing the issue.",
     "internal_only": false

--- a/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Please review the network configuration, and try re-installing the cluster. ROSA PrivateLink requirements are described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-aws-privatelink-creating-cluster#doc-wrapper"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_NoRouteToInternet.json
+++ b/osd/aws/InstallFailed_NoRouteToInternet.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Missing route to internet",
   "description": "Your cluster's installation is blocked because of the missing route to internet in the route table(s) associated with the supplied subnet(s) for cluster installation. Please review and validate the routes by following documentation and re-install the cluster: https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#rosa-vpc_rosa-sts-aws-prereqs"],
   "internal_only": false,
   "event_stream_id": ""
 }

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to ${MSG}. Please review the network configuration, and try re-installing the cluster. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
+++ b/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation is blocked due to there being no egress route defined in your cluster's private subnet. Please review the network configuration, and try re-installing the cluster. You can also refer to the following documentation about the requirements for AWS PrivateLink clusters: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-aws-privatelink-creating-cluster.html#osd-aws-privatelink-required-resources.adoc_rosa-aws-privatelink-creating-cluster.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-aws-privatelink-creating-cluster#doc-wrapper"],
   "internal_only": false
 }

--- a/osd/aws/InstallFailed_QuotaExceeded.json
+++ b/osd/aws/InstallFailed_QuotaExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on an AWS ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_RoleDeletionFailed.json
+++ b/osd/aws/InstallFailed_RoleDeletionFailed.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked. The cluster installer was not able to delete the roles it used during the installation. To unblock, please ensure that no policies are added to new roles by default.",
   "internal_only": false

--- a/osd/aws/InstallFailed_STS_PrivateLink.json
+++ b/osd/aws/InstallFailed_STS_PrivateLink.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations.",
   "internal_only": false

--- a/osd/aws/InstallFailed_SecurityGroupBeingModified.json
+++ b/osd/aws/InstallFailed_SecurityGroupBeingModified.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked as security groups used to provision the cluster on the AWS account were modified during installation. Please review any scripts which would modify the AWS resources automatically on the AWS account. Please make sure the required ports/protocols are allowed at all times. For more information please consult the documentation: https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html#rosa-security-groups_prerequisites.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index#rosa-security-groups_rosa-sts-aws-prereqs"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_TempAWSError.json
+++ b/osd/aws/InstallFailed_TempAWSError.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",
     "description": "Your cluster's installation failed due to a temporary AWS error while provisioning control plane instances. Please delete the cluster and retry installation.",
     "internal_only": false

--- a/osd/aws/InstallFailed_TooManyBucketObjectTags.json
+++ b/osd/aws/InstallFailed_TooManyBucketObjectTags.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked because S3 objects can only have 10 object tags. Please reduce the number of tags used on S3 objects in your AWS account and retry the installation. AWS S3 object tag limits are described in this document - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html.",
+    "doc_references": ["https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_TooManyBuckets.json
+++ b/osd/aws/InstallFailed_TooManyBuckets.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS TooManyBuckets error. Please raise the S3 bucket quota or remove some buckets from the appropriate region of your AWS account for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index#rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/aws/InstallFailed_lambda_automation_interfering.json
+++ b/osd/aws/InstallFailed_lambda_automation_interfering.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to automation in your AWS account which is interfering with the installation. ${REASON} Please remove or prevent this automation to allow installation to succeed.",
     "internal_only": false

--- a/osd/aws/InstallFailed_proxy_unreachable.json
+++ b/osd/aws/InstallFailed_proxy_unreachable.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Missing route to internet",
   "description": "Your cluster's installation is blocked because of the cluster-wide proxy configured is not reachable. Please review the network and proxy configuration before reattempting cluster installation process. - https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#configuring-a-cluster-wide-proxy"],
   "internal_only": false,
   "event_stream_id": ""
 }

--- a/osd/aws/MultipleVersionsOfEFSOperatorInstalled.json
+++ b/osd/aws/MultipleVersionsOfEFSOperatorInstalled.json
@@ -1,7 +1,9 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Multiple versions of EFS CSI driver installed on cluster",
     "description": "Red Hat has detected that your cluster is running multiple versions of EFS CSI driver. This configuration is not safe to use as this might lead to the EFS Operator not working as expected. Please use the officially supported version of EFS operator as described in https://access.redhat.com/solutions/4591701.",
+    "doc_references": ["https://access.redhat.com/solutions/4591701"],
     "internal_only": false
 }

--- a/osd/aws/NodeStuckTerminating.json
+++ b/osd/aws/NodeStuckTerminating.json
@@ -1,7 +1,9 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "AWS Delayed Instance Termination",
     "description": "Red Hat has identified an AWS instance issue that may impact your cluster. The instance '${INSTANCE_ID}' is currently in a 'shutting-down' state for an extended period of time. This condition normally resolves itself in a few hours. For more details, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesShuttingDown.html#instance-stuck-terminating.",
+    "doc_references": ["https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesShuttingDown.html#instance-stuck-terminating"],
     "internal_only": false
 }

--- a/osd/aws/ROSA_AWS_KMS_permissions_required.json
+++ b/osd/aws/ROSA_AWS_KMS_permissions_required.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to missing or insufficient privileges required by ROSA to access/use the customer-managed KMS key that has been supplied for encrypting instances. Please ensure that the appropriate IAM permissions are granted to the ManagedOpenShift roles to allow use of the key. For more information, please review the documentation: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations"],
     "internal_only": false
 }

--- a/osd/aws/ROSA_AWS_invalid_permissions.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-access",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#doc-wrapper"],
     "internal_only": false
 }

--- a/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster.  ${USER} is not authorized to perform ${REASON}. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index#rosa-sts-aws-prereqs"],
     "internal_only": false
 }

--- a/osd/aws/VPCEndpointLimitExceeded.json
+++ b/osd/aws/VPCEndpointLimitExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS VpcEndpointLimitExceeded error in given region. Please attempt to install the cluster again in another region. Meanwhile, Red Hat SRE team is working on increasing VpcEndpoint limit in affected region. The AWS account limits are described in this document -  https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/aws/VPCLimitExceeded.json
+++ b/osd/aws/VPCLimitExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation blocked on AWS VpcLimitExceeded error. Please raise the VPC quota or remove some VPCs from the appropriate region of your AWS account for the installation to succeed. AWS account limits are described in this document -  https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/aws/aws_outage_resolved.json
+++ b/osd/aws/aws_outage_resolved.json
@@ -1,7 +1,9 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
+  "log_type": "customer-support",
   "summary": "RESOLVED: AWS Outage Impacting Your Cluster",
   "description": "The AWS outage impacting your cluster has been resolved. For more details, including incident resolution, see https://health.aws.amazon.com/.",
+  "doc_references": ["https://docs.aws.amazon.com/health/latest/ug/first-time-user.html"],
   "internal_only": false
 }

--- a/osd/aws/invalid_kms_policy_byok.json
+++ b/osd/aws/invalid_kms_policy_byok.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Review KMS policy for master instance role",
   "description": "Your cluster requires you to take action because SRE monitoring stack persistent volume claims are failing to provision, resulting in Red Hat SRE not being able to monitor your cluster. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://access.redhat.com/articles/6155612.",
+  "doc_references": ["https://access.redhat.com/articles/6155612"],
   "internal_only": false,
   "_tags": [
     "sop_cluster_has_gone_missing"

--- a/osd/aws/sts_deleted_provider.json
+++ b/osd/aws/sts_deleted_provider.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Review OpenIDConnect provider configuration",
   "description": "Your cluster requires you to take action because the OpenIDConnect provider for this cluster could not be found. Please revert any changes to the OIDC provider to maintain ongoing cluster support.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-byo-oidc_rosa-sts-creating-a-cluster-with-customizations"],
   "internal_only": false
 }

--- a/osd/aws/sts_misconfigured_role.json
+++ b/osd/aws/sts_misconfigured_role.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-access",
   "summary": "Action required: Fix AWS Role to maintain SRE support",
   "description": "Your cluster requires you to take action because the IAM role `${ROLE}` has been modified in AWS, which is causing the following effect: `${EFFECT}`. Please revert the change to the IAM role to maintain ongoing cluster support.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-ocm-role"],
   "internal_only": false
 }

--- a/osd/aws/sts_thumbprint.json
+++ b/osd/aws/sts_thumbprint.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-access",
   "summary": "Action required: update cluster OIDC thumbprint",
   "description": "OpenShift SREs have detected your OpenIDConnect Provider thumbprint has changed. Please follow the documentation to update your thumbprint: https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html#rosa-sts-oidc-provider-for-operators-aws-cli_rosa-sts-about-iam-resources. Update the OIDC thumbprint with the command 'aws iam update-open-id-connect-provider-thumbprint', or through the AWS Console under IAM -> Identity Providers.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources#rosa-sts-oidc-provider-requirements-for-operators_rosa-sts-about-iam-resources"],
   "internal_only": false
 }

--- a/osd/aws/unable_to_create_machines_aws_capacity.json
+++ b/osd/aws/unable_to_create_machines_aws_capacity.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Cluster machine creation blocked, action required",
     "description": "Your cluster is blocked on an AWS datacenter capacity issue. AWS does not have capacity for ${INSTANCE_TYPE} in ${REGION} at the moment. Please select a different instance type.",
     "internal_only": false

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: Address Incorrect Security Context Constraint Configuration",
   "description": "Your cluster requires you to take action because an incorrect Security Context Constraint (SCC) Priority exists on the cluster - ${SCC_NAME}. This SCC has been applied to an Openshift managed namespace and it is impacting cluster functions. Without action, your cluster's SLA may be impacted. Please remove or amend the SCC by following the documentation - https://docs.openshift.com/dedicated/authentication/managing-security-context-constraints.html#role-based-access-to-ssc_configuring-internal-oauth.",
+  "doc_references" : ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/managing-pod-security-policies#scc-prioritization_configuring-internal-oauth"],
   "internal_only": false
 }

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -1,8 +1,10 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: Cluster proxy CA Expiring",
   "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/cluster-wide_proxy_unreachable.json
+++ b/osd/cluster-wide_proxy_unreachable.json
@@ -1,8 +1,10 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-networking",
     "_tags": ["t_network"],
     "summary": "Action required: update cluster proxy state/configuration",
     "description": "The cluster-wide proxy configured for your OpenShift cluster is currently reporting as unavailable to the cluster: ${REASON}. This impacts your cluster's network egress, including ability to pull system images, run cluster operators, manage instances and perform upgrade-related actions. Please review your proxy server's state and configuration to restore the cluster's functionality. Please refer to the documentation for further information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
+    "doc_referenes": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy#configuring-a-proxy-after-installation_configuring-a-cluster-wide-proxy"],
     "internal_only": false
 }

--- a/osd/cluster_alerting_with_no_sre_access.json
+++ b/osd/cluster_alerting_with_no_sre_access.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-access",
     "summary": "Attention requested: Cluster account access unavailable",
     "description": "SRE has been notified of problems on your cluster, but cannot investigate because cloud provider access has been removed. If you intended to terminate this cluster then please delete the cluster in the Red Hat console.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"],
     "internal_only": false
 }

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -2,7 +2,9 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Cluster destroyed, cannot be recovered",
+  "log_type": "cluster-lifecycle",
   "description": "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/osd_quickstart/osd-quickstart.html#deleting-cluster_osd-getting-started.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "sop_cluster_has_gone_missing",

--- a/osd/cluster_has_gone_missing.json
+++ b/osd/cluster_has_gone_missing.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: cluster not checking in",
   "description": "Your cluster requires you to take action because it is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopping instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "sop_cluster_has_gone_missing",

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type":"cluster-networking",
   "summary": "Action required: update cluster configuration",
   "description": "Red Hat SRE have noticed a second ingress controller installed in the ‘openshift-ingress-operator’ namespace. This is currently not possible in Managed OpenShift. Please remove the second ingress controller. Custom Domains operator may address your usecase: https://docs.openshift.com/dedicated/applications/deployments/osd-config-custom-domains-applications.html.",
+  "doc_references": ["https://access.redhat.com/solutions/6970094"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#rosa-scaling-worker-nodes_rosa-managing-worker-nodes"],
     "internal_only": false
 }

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: update cluster proxy configuration",
   "description": "The clusterwide openshift proxy is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. See documentation: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html.",
   "internal_only": false,

--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network"],
   "summary": "Action required: update cluster proxy configuration",
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the OCM CLI: https://docs.openshift.com/dedicated/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy#configuring-a-proxy-after-installation_configuring-a-cluster-wide-proxy"],
   "internal_only": false
 }

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network"],
   "summary": "Action required: update cluster proxy configuration",
   "description": "Your cluster requires you to take action. The cluster-wide proxy configuration for this cluster is missing a Certificate Authority that allows your cluster to trust HTTPS communications that go via the proxy. Please add your proxy's Certificate Authority certificate(s) to your cluster so that they can be used to verify proxy traffic. This process can be performed via the ROSA CLI: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy#configuring-a-proxy-after-installation_configuring-a-cluster-wide-proxy"],
   "internal_only": false
 }

--- a/osd/cluster_stuck.json
+++ b/osd/cluster_stuck.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "Action required: Cluster Stuck",
     "description": "SRE has observed that your cluster is stuck in an ${STATE} state. If you need assistance to fully remove and cleanup your cluster, please open a support case.",
+    "doc_references": ["https://access.redhat.com/support/cases/new"],
     "internal_only": false
 }

--- a/osd/controlplane_resized.json
+++ b/osd/controlplane_resized.json
@@ -1,8 +1,10 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-scaling",
     "event_stream_id": "${JIRA_ID}",
     "summary": "Control plane resized",
     "description": "SRE has observed ${JUSTIFICATION}. SRE has resized the control plane nodes of your cluster to ${INSTANCE_TYPE} to accommodate cluster load.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-limits-scalability#node-scaling-after-installation_rosa-limits-scalability"],
     "internal_only": false
 }

--- a/osd/custom_domain_cert_misconfiguration.json
+++ b/osd/custom_domain_cert_misconfiguration.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: update custom domain configuration",
   "description": "The custom application domain '${CUSTOM_DOMAIN}' has a malformed or misconfigured certificate. Please review the certificate provided by the '${SECRET}' secret in the '${SECRET_NS}' namespace to restore functionality to your cluster. For additional information on custom-domains-operator, refer to the following documentation: https://access.redhat.com/articles/5599621.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-applications-renew-custom-domains_osd-config-custom-domains-applications"],
   "internal_only": false
 }

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: update custom domain configuration",
   "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/customer_alert_blocking_upgrade.json
+++ b/osd/customer_alert_blocking_upgrade.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-updates",
   "summary": "Action required: Cluster Upgrade Blocked",
   "description": "Your cluster requires you to take action because ${PROBLEM}. This is blocking your cluster from upgrading successfully. Please ${REQUIRED_CUSTOMER_ACTION} so that your cluster upgrade can proceed. Without action, your cluster's SLA may be impacted. Please refer to this documentation for more information: ${DOCUMENTATION}.",
   "internal_only": false,

--- a/osd/customer_clusteroperator_down.json
+++ b/osd/customer_clusteroperator_down.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Action required: Remove or address failing cluster operator",
     "description": "Your cluster requires you to take action because there is a custom ClusterOperator named '${NAME}' installed on the cluster, which is failing to reach an Available state. Unavailable or degraded ClusterOperators can prevent your cluster's ability to upgrade to future versions successfully. Please address or remove the ClusterOperator to allow your cluster to remain in an upgradeable state.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/operators/administrator-tasks#olm-troubleshooting-operator-issues"],
     "internal_only": false
 }

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-scaling",
     "summary": "Action required: Pod emptydir storage preventing Node Drain",
     "description": "Your cluster is attempting to drain a node but there is a pod using emptydir storage that is preventing the drain. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please re-schedule this pod so that the node can drain. For more information on ephemeral storage please see https://docs.openshift.com/container-platform/latest/storage/understanding-ephemeral-storage.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-pod-affinity"],
     "internal_only": false
 }

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: Unsupported change to worker node instances",
   "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",

--- a/osd/customer_pdb_preventing_drain.json
+++ b/osd/customer_pdb_preventing_drain.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",
   "description": "Your cluster is attempting to drain node `${NODE}` but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as `${POD}` running in the namespace: `${NAMESPACE}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/dedicated/nodes/pods/nodes-pods-configuring.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
   "internal_only": false,
   "_tags": [
     "sop_KubeNodeUnschedulableSRE",

--- a/osd/customer_pdb_preventing_drain_automated.json
+++ b/osd/customer_pdb_preventing_drain_automated.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Pod Disruption Budget(s) preventing Node Drain",
     "description": "Your cluster is attempting to drain the node(s): `${NODELIST}` but there is a pod disruption budget set that is preventing the drain. The Managed OpenShift SRE team has identified the following workload(s) affected in namespace/pod-name format: `${PODLIST}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/dedicated/nodes/pods/nodes-pods-configuring.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
     "internal_only": false
 }

--- a/osd/customer_pod_preventing_drain.json
+++ b/osd/customer_pod_preventing_drain.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Pod(s) preventing Node Drain",
   "description": "Your cluster is attempting to drain a node but there are pod(s) preventing the drain. The SRE team has identified the pod(s) as '${POD}' running in namespace(s) '${NAMESPACE}'. Please re-schedule the impacted pod(s) so that the node can drain.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
   "internal_only": false,
   "_tags": [
     "sop_KubeNodeUnschedulableSRE",

--- a/osd/customer_pods_preventing_drain_automated.json
+++ b/osd/customer_pods_preventing_drain_automated.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Pod(s) preventing Node Drain",
     "description": "Your cluster is attempting to drain worker nodes but there are workloads preventing the drain. The SRE team has identified the affected nodes as `${NODELIST}` and the pod(s) as the following in 'namespace/pod-name' format: `${PODLIST}`. Please re-schedule the impacted pod(s) so that the node can drain.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
     "internal_only": false
 }

--- a/osd/customer_stopped_control_plane_node.json
+++ b/osd/customer_stopped_control_plane_node.json
@@ -1,6 +1,7 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Action required: Restart control plane node",
     "description": "Your cluster requires you to take action. Red Hat SRE have observed that a user `${USER}` has stopped one or more of your cluster's control plane instances: `${INSTANCE}`. Please note that stopping instances is not supported and may impact your cluster's SLA and ability to upgrade. Refer to the Responsibility Assignment guide for more information: https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
     "internal_only": false

--- a/osd/customer_stopped_control_plane_node_rosa.json
+++ b/osd/customer_stopped_control_plane_node_rosa.json
@@ -1,6 +1,7 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Action required: Restart control plane node",
     "description": "Your cluster requires you to take action. Red Hat SRE have observed that a user `${USER}` has stopped one or more of your cluster's control plane instances: `${INSTANCE}`. Please note that stopping instances is not supported and may impact your cluster's SLA and ability to upgrade. Refer to the Responsibility Assignment guide for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html.",
     "internal_only": false

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: DNS misconfigration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to DNS configuration which impact normal working of the cluster. Please revert these changes.",
   "internal_only": false,

--- a/osd/eol_date_extended.json
+++ b/osd/eol_date_extended.json
@@ -1,7 +1,9 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Product end-of-life date extended",
     "description": "The end-of-life cycle date for ${PRODUCT} is being extended to ${EOLDATE}. Please refer to our life cycle policy document for further information: ${DOCUMENTATION}.",
+    "doc_references" : ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-life-cycle"],
     "internal_only": false
 }

--- a/osd/failing_api_service.json
+++ b/osd/failing_api_service.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: correct failing API services",
     "description": "The '${API_SERVICE}' extension API service installed on your cluster is currently failing. This failing service can impact your cluster's ongoing operation and resource management. Please validate and correct or otherwise remove the failing API Service.",
     "internal_only": false

--- a/osd/gcp/GCP_Network_Misconfig.json
+++ b/osd/gcp/GCP_Network_Misconfig.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Action required: Failed Openshift Installation on GCP",
     "description": "Your cluster's installation is blocked by a networking misconfiguration. Please review the network configuration, and try re-installing the cluster. GCP VPC requirements are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html.",
     "internal_only": false

--- a/osd/gcp/GCP_Service_API_Disabled.json
+++ b/osd/gcp/GCP_Service_API_Disabled.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action Required: enable required service APIs",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is malfunctioning because required GCP service APIs are disabled. Please enable the following API(s) in your GCP account: ${SERVICE_APIS}. Please consult the documentation for more details: ${DOCS_LINK}.",
     "internal_only": false

--- a/osd/gcp/GCP_outage _resolved.json
+++ b/osd/gcp/GCP_outage _resolved.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "RESOLVED: GCP Outage Impacting Your Cluster",
     "description": "The GCP outage impacting your cluster has been resolved. For more details, including incident resolution, see https://status.cloud.google.com/.",
     "internal_only": false

--- a/osd/gcp/GCP_outage.json
+++ b/osd/gcp/GCP_outage.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "GCP Outage Impacting Your Cluster",
     "description": "Red Hat has identified a GCP issue that may impact your cluster. For more details, including incident resolution, see https://status.cloud.google.com/.",
     "internal_only": false

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: review account quota",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
     "internal_only": false
 }

--- a/osd/gcp/InstallFailed_GCP_Capacity.json
+++ b/osd/gcp/InstallFailed_GCP_Capacity.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on an GCP datacenter capacity issue. GCP does not have capacity for ${INSTANCE_TYPE} in ${REGION} at the moment. Please retry installation in another region or select a different instance type.",
     "internal_only": false

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account.",
     "internal_only": false

--- a/osd/gcp/invalid_iaas_credentials.json
+++ b/osd/gcp/invalid_iaas_credentials.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Restore missing cloud credentials",
     "description": "Your cluster requires you to take action because Red Hat SRE is not able to access the cloud provider infrastructure with the provided credentials in order to support your cluster. Please restore the credentials and permissions provided during install. For more information on the IAM roles and accesses required, please refer to the documentation available at: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/install_rosa_classic_clusters/index#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly"],
     "internal_only": false
 }

--- a/osd/generic_customer_support_case_notification.json
+++ b/osd/generic_customer_support_case_notification.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "Action required: Support case ${CASE_ID}",
     "description": "Your cluster requires you to take action because ${PROBLEM}, resulting in ${IMPACT}. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this customer support case https://access.redhat.com/support/cases/#/case/${CASE_ID}.",
     "internal_only": false

--- a/osd/generic_deprovision_failed.json
+++ b/osd/generic_deprovision_failed.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Deprovision failed, action required",
     "description": "Your cluster's deprovision is blocked because ${PROBLEM}. Please review and validate the following documentation to enable the deprovision to succeed: ${DOCUMENTATION}.",
     "internal_only": false

--- a/osd/generic_install_failed.json
+++ b/osd/generic_install_failed.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation is blocked because ${PROBLEM}. Please review and validate the following documentation to enable the installation to succeed: ${DOCUMENTATION}.",
   "internal_only": false,

--- a/osd/generic_problem_notification.json
+++ b/osd/generic_problem_notification.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "Action required: ${PROBLEM_SUMMARY}",
     "description": "Your cluster requires you to take action because ${PROBLEM}, resulting in ${IMPACT}. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: ${DOCUMENTATION}.",
     "internal_only": false

--- a/osd/hive_migration.json
+++ b/osd/hive_migration.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "${DATE} Upcoming Maintenance: OpenShift Cluster Manager actions will be unavailable during this maintenance",
     "description": "The ability to modify your cluster through OpenShift Cluster Manager will be affected by an upcoming maintenance on ${DATE} at ${TIME} UTC. We expect this maintenance to last ${DURATION}. During this maintenance, you will be unable to perform actions such as add or remove nodes, configure administrators, add or remove identity providers, etc. We recommend that you perform any such actions prior to this maintenance.",
     "internal_only": false

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: update identity provider configuration",
   "description": "Please verify the status of your identity server and update the IdP '${IDP_PROVIDER}' configuration to restore the cluster's operation. See documentation: https://docs.openshift.com/dedicated/identity_providers/config-identity-providers.html.",

--- a/osd/ignore_previous_message.json
+++ b/osd/ignore_previous_message.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "customer-support",
     "summary": "Please ignore previous message",
     "description": "Previous message was sent in error. Please ignore it.",
     "internal_only": false

--- a/osd/incident_resolved.json
+++ b/osd/incident_resolved.json
@@ -1,6 +1,7 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
+  "log_type": "customer-support",
   "summary": "Cluster incident resolved",
   "description": "cluster incident '${ALERT_NAME}' is resolved.",
   "internal_only": false,

--- a/osd/incorrect_PodDisruptionBudget.json
+++ b/osd/incorrect_PodDisruptionBudget.json
@@ -1,6 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action Required: Incorrect Pod Disruption Budget configuration",
-    "description": "SRE have noticed that your cluster's workload ${WORKLOAD} is using a Pod Disruption Budget (PDB) configuration which can affect the cluster's operation. A maxUnavailable of 0% or 0 or a minAvailable of 100% or equal to the number of replicas is permitted but can block nodes from being drained, hence cluster upgrades can also be impacted. We recommend reviewing your Pod Disruption Budget configurations using the documentation guidelines for setting PDB https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring."
+    "description": "SRE have noticed that your cluster's workload ${WORKLOAD} is using a Pod Disruption Budget (PDB) configuration which can affect the cluster's operation. A maxUnavailable of 0% or 0 or a minAvailable of 100% or equal to the number of replicas is permitted but can block nodes from being drained, hence cluster upgrades can also be impacted. We recommend reviewing your Pod Disruption Budget configurations using the documentation guidelines for setting PDB https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"]
 }
+

--- a/osd/infranode_resized.json
+++ b/osd/infranode_resized.json
@@ -1,8 +1,10 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-scaling",
     "event_stream_id": "${JIRA_ID}",
     "summary": "Infra nodes resized",
     "description": "SRE has observed ${JUSTIFICATION}. SRE has resized the infra nodes of your cluster to ${INSTANCE_TYPE} to accommodate cluster load.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-limits-scalability#node-scaling-after-installation_rosa-limits-scalability"],
     "internal_only": false
 }

--- a/osd/infranode_resized_auto.json
+++ b/osd/infranode_resized_auto.json
@@ -2,7 +2,9 @@
     "severity": "Info",
     "_tags": ["t_config"],
     "service_name": "SREManualAction",
+    "log_type": "cluster-scaling",
     "summary": "Infra nodes resized",
     "description": "SRE has resized the infra nodes of your cluster to ${INSTANCE_TYPE} to accommodate cluster load. For more information, please visit https://docs.openshift.com/rosa/rosa_planning/rosa-limits-scalability.html#node-scaling-after-installation_rosa-limits-scalability to learn more.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-limits-scalability#node-scaling-after-installation_rosa-limits-scalability"],
     "internal_only": false
 }

--- a/osd/install_failed_please_retry
+++ b/osd/install_failed_please_retry
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-access",
   "summary": "Installation blocked, action required",
   "description": "Your cluster's installation has failed due to an intermittent issue. Please install again.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "sop_ClusterProvisioningFailure"

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Restore missing cloud credentials",
   "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/install_rosa_classic_clusters/index#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly"],
   "internal_only": false,
   "_tags": [
     "t_config",

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-access",
   "summary": "Action required: Fix AWS Role to maintain SRE support",
   "description": "Your cluster requires you to take action because Red Hat OpenShift SRE are not able to access your AWS account due to ${REASON} in ${IAM_ROLE_NAME} IAM role that prevents SRE from supporting your cluster. Please fix the IAM role to maintain ongoing cluster support. If you intended to terminate this cluster then please delete the cluster.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-ocm-role"],
   "internal_only": false,
   "_tags": [
     "t_config",

--- a/osd/limited_support/LimitedSupportCloud.json
+++ b/osd/limited_support/LimitedSupportCloud.json
@@ -1,5 +1,8 @@
 {
+    "severity": "Info",
     "summary": "Cluster is in Limited Support due to unsupported cloud provider configuration",
+    "log_type": "cluster-configuration",
     "details": "${CONFIGURATION}",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-limited-support_rosa-life-cycle"],
     "detection_type": "manual"
 }

--- a/osd/limited_support/LimitedSupportCluster.json
+++ b/osd/limited_support/LimitedSupportCluster.json
@@ -1,4 +1,6 @@
 {
+    "severity": "Info",
+    "log_type": "cluster-configuration",
     "summary": "Cluster is in Limited Support due to unsupported cluster configuration",
     "details": "${CONFIGURATION}",
     "detection_type": "manual"

--- a/osd/limited_support/scheduled_chaos_test.json
+++ b/osd/limited_support/scheduled_chaos_test.json
@@ -1,5 +1,7 @@
 {
+    "severity": "Info",
     "summary": "Cluster is in Limited Support due to scheduled chaos testing",
+    "log_type": "customer-support",
     "details": "Your cluster is in Limited Support due to a scheduled chaos test. Chaos testing includes AZ outage testing, network testing, disaster recovery testing, etc. Once your testing is complete, please reach out to Red Hat Support to resume full-support of your cluster",
     "detection_type": "manual"
 }

--- a/osd/maintenance_completed.json
+++ b/osd/maintenance_completed.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "${DATE} Cluster maintenance successfully completed",
     "description": "${DATE} cluster maintenance is now successfully completed. Your cluster services are now fully back online.",
     "internal_only": false

--- a/osd/maintenance_starting.json
+++ b/osd/maintenance_starting.json
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "${DATE} Cluster maintenance is starting",
     "description": "${DATE} cluster maintenance is starting. We expect the cluster to be available during this time.",
     "internal_only": false

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Platform component monitoring accessed by non-Red Hat SRE user",
   "description": "A workload or user on your system has accessed or modified the configuration of the cluster monitoring stack, which is the responsibility of Red Hat SRE. Changes to the cluster-monitoring-config in the openshift-monitoring namespace can interfere with Red Hat's ability to monitor the cluster, and can endanger SLAs. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
   "internal_only": false
 }

--- a/osd/no_resources_to_run_userworkloadmonitoring.json
+++ b/osd/no_resources_to_run_userworkloadmonitoring.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: User Workload Monitoring impacted by cluster resource limits",
     "description": "Your cluster requires you to take action. Your cluster's worker nodes do not have enough resources to run the cluster's User Workload Monitoring monitoring stack. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.",
+    "doc_referneces": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-clusters#nodes-cluster-limit-ranges"],
     "internal_only": false
 }

--- a/osd/osd_too_old_upgrade_needed.json
+++ b/osd/osd_too_old_upgrade_needed.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Action required: Upgrade cluster before ${CUTOFF_DATE}",
     "description": "Your cluster is running a soon to be unsupported OSD version. Please upgrade to a supported version of OSD before ${CUTOFF_DATE}. Failing to upgrade will result in your cluster becoming unsupported and SRE monitoring of it being disabled, per our Life Cycle Policy, available at https://access.redhat.com/support/policy/updates/openshift/dedicated.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/index"],
     "internal_only": false
 }

--- a/osd/persistentvolume_resized.json
+++ b/osd/persistentvolume_resized.json
@@ -1,7 +1,9 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Persistent Volume/s Resized",
     "description": "Red Hat SRE have detected a high usage of storage on the ${STORAGE_LOCATION} due to ${REASON_FOR_USAGE} so to avoid losing data Red Hat SRE have reduced the retention to ${NEW_RETENTION_DURATION}. Please take action if you wish to increase the retention again.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/configuring-the-monitoring-stack#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack"],
     "internal_only": false
 }

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/latest/cicd/pipelines/reducing-pipelines-resource-consumption.html.",
+    "doc_references": ["https://docs.openshift.com/pipelines/latest/resource/reducing-pipelines-resource-consumption.html"],
     "internal_only": false
 }

--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: Cluster-wide proxy network requirements not met",
   "description": "Your cluster requires you to take action because the required URLs are not configured to be excluded from cluster-wide proxy re-encryption, resulting in cluster's monitoring stack not functioning correctly. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#configuring-a-cluster-wide-proxy"],
   "internal_only": false
 }

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: Review pull secret",
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster, specifically the 'cloud.redhat.com' token is either missing or is not associated with the cluster owner. Without this, Red Hat SRE's ability to monitor and support your cluster will be impacted, as will your cluster's ability to initiate any upgrades. Please ensure that the pull secret contains the contents of the pull secret available from https://console.redhat.com/openshift/downloads. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/images/managing-images#using-image-pull-secrets"],
   "internal_only": false
 }

--- a/osd/pull_secret_rotated.json
+++ b/osd/pull_secret_rotated.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Cluster pull secret updated",
     "description": "The pull secret associated with account '${ACCOUNT}' has been rotated by Red Hat SRE in order to ensure that your cluster has successful connectivity to the Red Hat Registry and OpenShift Cluster Manager. Should you wish, you may download the updated copy of your pull secret from https://console.redhat.com/openshift/downloads#tool-pull-secret. This is an informational notice and no further action is required by you.",
     "internal_only": false

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Review pull secret",
   "description": "Your cluster requires you to take action because the Red Hat Site Reliability Engineering (SRE) have detected that your cluster's pull secret has been updated or modified by a user on your cluster. The user in the updated pull-secret doesn't match the cluster owner. Please fix the pull-secret, as the current configuration impacts Red Hat SRE's ability to monitor and operate your cluster, and your cluster's ability to initiate any upgrades.",
+  "doc_references": ["https://docs.openshift.com/container-platform/4.14/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets"],
   "internal_only": false,
   "_tags": [
     "t_config",

--- a/osd/recover_master_node_is_required.json
+++ b/osd/recover_master_node_is_required.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Cluster does not have sufficient number of master nodes",
     "description": "SRE have noticed a change in the state of one or more of the cluster's master nodes. Please note that if you change the running state of one of the master nodes manually this may impact the stability of the cluster and the cluster's SLA. We suggest you to revert any changes made on master instances.",
     "internal_only": false

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecyle",
     "summary": "SRE recovered master nodes",
     "description": "SRE has noticed a change in the state of one or more of the cluster's master nodes. SRE has restored the affected nodes. Please note that changing the running state of one of the master nodes manually will result in loss of cluster functionality and will impact your cluster's SLAs.",
     "internal_only": false

--- a/osd/registry_access_denied.json
+++ b/osd/registry_access_denied.json
@@ -1,7 +1,9 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: image-registry gets AccessDenied error",
   "description": "Your cluster requires you to take action because image-registry operator is degraded due to an access denied error, resulting in your cluster being unable to start pods requiring new images from the local registry. Please verify permissions to the S3 bucket (${S3_BUCKET}) and the operator role (${OPERATOR_ROLE}) to allow access from the role to the bucket. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],
   "internal_only": false
 }

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please refer to the following firewall pre-requisites which are required for PrivateLink clusters: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites. Please revert changes.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/resize_master_etcd_bz_2068601
+++ b/osd/resize_master_etcd_bz_2068601
@@ -1,6 +1,7 @@
 {
     "severity": "Info",
     "service_name": "SREManualAction",
+    "log_type": "cluster-scaling",
     "summary": "${DATE}: Control plane resize to ${INSTANCE_TYPE} beginning",
     "description":  "Cluster control plane is being proactively scaled up in response to https://bugzilla.redhat.com/show_bug.cgi?id=2068601. Cluster has been identified as having high resource utilization and is at risk of being affected by etcd fragmentation.",
     "internal_only": false

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-access",
   "summary": "Installation blocked, action required",
   "description": "Your ROSA STS cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster. Please review and validate the pre-requisites required on your AWS account for the installation to succeed. Pre-requisites are described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-aws-prereqs.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "t_config",

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network"],
   "summary": "Invalid TLS certificate",
   "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
   "internal_only": false
 }

--- a/osd/rosa_cluster_cannot_be_recovered.json
+++ b/osd/rosa_cluster_cannot_be_recovered.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-lifecyle",
   "summary": "Cluster destroyed, cannot be recovered",
   "description": "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster"],
   "internal_only": false,
   "_tags": [
     "sop_cluster_has_gone_missing"

--- a/osd/rosa_cluster_cant_manage_instances.json
+++ b/osd/rosa_cluster_cant_manage_instances.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Cluster degraded, action required",
     "description": "Your cluster is unable to manage its AWS EC2 instances using AWS API operations such as ec2:RunInstances and ec2:TerminateInstances, which prevents critical cluster functions from operating. This can be caused by insufficient AWS IAM permissions, insufficient AWS quota or ABAC policies blocking AWS instance operations. Please review ROSA pre-requisites as described in this document - https://docs.openshift.com/rosa/rosa_planning/rosa-aws-prereqs.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],
     "internal_only": false
 }

--- a/osd/rosa_cluster_destroyed_cluster_admin.json
+++ b/osd/rosa_cluster_destroyed_cluster_admin.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Cluster destroyed, cannot be recovered",
     "description": "SRE have noticed that the core configuration of your cluster has been modified by a user leveraging cluster-admin permissions. The cluster cannot be restored to a managed state, please delete it following the documentation guidelines: https://docs.openshift.com/rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html. Please open a support case if you need any assistance.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster"],
     "internal_only": false
 }

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster Logging configuration",
     "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation via 'Verification steps' section mentioned in doc: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_logging/rosa-install-logging.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/cluster-logging-deploying"],
     "internal_only": false
 }

--- a/osd/rosa_customer_pdb_preventing_drain.json
+++ b/osd/rosa_customer_pdb_preventing_drain.json
@@ -1,8 +1,10 @@
 {  
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",
   "description": "Your cluster is attempting to drain node `${NODE}` but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as `${POD}` running in the namespace: `${NAMESPACE}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/rosa/nodes/pods/nodes-pods-configuring.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
   "internal_only": false,
   "_tags": [
     "sop_KubeNodeUnschedulableSRE",

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-networking",
     "summary": "Invalid TLS certificate",
     "description": "Your cluster uses an invalid TLS certificate. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
     "internal_only": false
 }

--- a/osd/rosa_no_egress_route.json
+++ b/osd/rosa_no_egress_route.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: Network misconfiguration",
   "description": "Your cluster requires you to take action. SRE has observed that there is no egress route defined in your cluster's private subnet which impacts normal working of the cluster. Please refer to the rosa documentation on how to setup the route tables for private subnets: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#sample-vpc-architecture .",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-aws-privatelink-creating-cluster#osd-aws-privatelink-required-resources.adoc_rosa-aws-privatelink-creating-cluster"],
   "internal_only": false
 }

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Cluster Degraded, action required",
   "description": "Your cluster's health is degraded due a Service Control Policy (SCP) preventing administrator access in the AWS acction. Please review and validate the minimum requires SCP required on your AWS account to restore the cluster health. The minimum required SCP is described in this document - https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-minimum-scp_prerequisites.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-cloud-expert-prereq-checklist#scp-prerequisites"],
   "internal_only": false
 }

--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: remove second monitoring stack",
     "description": "Red Hat SRE have noticed a second monitoring stack installed in the '${NAMESPACE}' namespace. This is interfering with cluster operations and preventing Red Hat from monitoring the cluster. Please remove the adhoc monitoring stack and use User Workload Monitoring instead. See https://docs.openshift.com/rosa/monitoring/monitoring-overview.html#understanding-the-monitoring-stack_monitoring-overview.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/monitoring-overview#understanding-the-monitoring-stack_monitoring-overview"],
     "internal_only": false
 }

--- a/osd/security_update_available.json
+++ b/osd/security_update_available.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-security",
     "summary": "Important security update available",
     "description": "Your cluster has an important security update available. Details are available at ${ADVISORY_URL}.",
+    "doc_referencs": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading"],
     "internal_only": false
 }

--- a/osd/silence_namespace_alerts_notice.json
+++ b/osd/silence_namespace_alerts_notice.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "NOTICE: Silencing alerts for 'openshift-*' user namespaces",
     "description": "The Red Hat SRE team monitors all namespaces matching pattern 'openshift-*' in the cluster. This namespace prefix is reserved for infrastructure use. Red Hat SRE does not monitor user namespaces matching this pattern. Alerts for namespace '${NAMESPACE}' have been silenced and will not be re-enabled. Cluster metrics and alerts may still be accessed from the cluster console.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/managing-metrics#about-querying-metrics_managing-metrics"],
     "internal_only": false
 }

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Address storageclass configuration",
   "description": "Your cluster requires you to take action because its StorageClass resources have been customized in a way that is resulting in components of the cluster's monitoring stack from failing to provision Persistent Volumes, which impacts the availability of your cluster's monitoring stack. Please ensure to properly configure the cluster default storage class.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/using-container-storage-interface-csi#persistent-storage-csi-sc-manage"],
   "internal_only": false,
   "_tags": [
     "t_config",

--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -1,8 +1,10 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "_tags": ["t_config"],
     "summary": "Action required: Disable termination protection on cluster instances",
     "description": "Your cluster is attempting to drain and replace `${NODE_TYPE}` node(s) `${NODE}` but cannot remove them due to EC2 termination protection being applied to the instances. Please modify the `disableApiTermination` instance attribute to allow the instances to be properly terminated and replaced. For more information, please review AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html .",
+    "doc_references": ["https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html"],
     "internal_only": false
 }

--- a/osd/unevictable_workload.json
+++ b/osd/unevictable_workload.json
@@ -1,6 +1,7 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Unevictable workload detected",
     "description": "Your cluster is attempting to evict a pod from node ${NODE} but ${REASON} is blocking that. Please ensure that this issue is addressed in the configuration of your application. Otherwise, the ability to autoscale the cluster may be impacted.",
     "internal_only": false

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -1,6 +1,7 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Cluster incident identified",
   "description": "Your cluster is identified to have a general failure regarding the alert '${ALERT_NAME}'. The initial issue can be described as '${BRIEF_DESCRIPTION}'. A diagnosis of the issue is underway.",
   "internal_only": false,

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,8 +1,10 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: Unschedulable customer workload pod",
   "description": "Your cluster is attempting to run a pod but ${REASON} that is preventing the pod from being scheduled. The OSD SRE team has identified the pod as ${POD} running in ${NAMESPACE}. Please ${FIX} so that the pod can run. For more information on pod scheduling please see https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-about.html.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/controlling-pod-placement-onto-nodes-scheduling"],
   "internal_only": false
 }

--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Remove custom workload from control plane/infra nodes",
   "description": "Your cluster requires you to take action because there is a custom workload scheduled on control plane/infra nodes: ${WORKLOAD}. The control plane and infrastructure nodes are reserved for Red Hat workloads required to operate the service, as described in the Red Hat OpenShift Dedicated Service Definition. Custom workloads can negatively impact the availability/supportability of control plane and infrastructure nodes. Please ensure this workload does not schedule to these nodes. For more information please refer to https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-sdpolicy-instance-types_rosa-service-definition"],
   "internal_only": false,
   "_tags": [
     "sop_ExtremelyHighIndividualControlPlaneCPU"

--- a/osd/update_pull_secret.json
+++ b/osd/update_pull_secret.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Review pull secret",
     "description": "Your cluster requires you to take action because the cluster is reporting that it is unauthorized to pull images from ${REGISTRY}. Without this, image pulls from that registry will not succeed and may impact Red Hat SRE's ability to monitor and support your cluster. Please ensure that the cluster's global pull secret is using correct authentication for the ${REGISTRY} registry. For more information, see the 'Updating the global pull secret' section of documentation URL https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html.",
+    "doc_referneces": ["https://docs.openshift.com/container-platform/4.14/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets"],
     "internal_only": false
 }

--- a/osd/upgrade_blocked.json
+++ b/osd/upgrade_blocked.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",
     "description": "Your cluster is unable to complete its upgrade because ${REASON}. SRE has observed the following: ${OBSERVATION}. Please take steps to resolve the issue in order for your cluster to finish upgrading.",
     "internal_only": false

--- a/osd/upgrade_blocked_with_docs.json
+++ b/osd/upgrade_blocked_with_docs.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",
     "description": "Your cluster is unable to complete upgrade because ${REASON}. SRE has observed the following: ${OBSERVATION}. Please take steps to resolve the issue in order for your cluster to finish upgrading. Additional documentation can be found at ${DOCUMENTATION}.",
     "internal_only": false

--- a/osd/upgrade_cluster_version.json
+++ b/osd/upgrade_cluster_version.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Action Required: Upgrade cluster version",
     "description": "Red Hat has identified a bug on the current version of your cluster, ${CURRENT_VERSION}. You can review the details of this bug at ${BZ_LINK}. Red Hat recommends you upgrade as soon as possible to the latest available ${LATEST_VERSION} release.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/rosa-upgrading-sts"],
     "internal_only": false
 }

--- a/osd/upgrade_paused_acknowledgement.json
+++ b/osd/upgrade_paused_acknowledgement.json
@@ -1,7 +1,9 @@
 {
     "severity": "Warning",
     "service_name": "SREManualAction",
+    "log_type": "cluster-updates",
     "summary": "Action Required: Cluster upgrade paused, requires acknowledgement",
     "description": "Your cluster's upgrade cannot proceed because manual acknowledgement is required concerning the removal of deprecated APIs. Please review the Knowledge Base article at https://access.redhat.com/articles/6329921 and perform the recommended acknowledgement procedure if you are not using workloads that require the deprecated APIs and wish to proceed with the upgrade - the upgrade will then proceed as normal.",
+    "doc_references": ["https://access.redhat.com/articles/6329921"],
     "internal_only": false
 }

--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -1,6 +1,7 @@
 {
   "severity": "Info",
   "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
   "summary": "Action required: Misconfigured additional Trusted CA bundle",
   "description": "Your cluster requires you to take action because the Additional Trusted CA Bundle that you have applied to your cluster is corrupt or cannot be correctly parsed. This may impact your cluster's ability to communicate with any external resources that require that bundle, including those accessible via a cluster-wide proxy. Please remove or update the Additional Trusted CA Bundle to ensure it is in a parseable, plaintext PEM-formatted format. For more information, see: https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html.",
   "internal_only": false,

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "_tags": ["t_config"],
   "summary": "Action required: review user-workload-monitoring configuration",
   "description": "Your cluster's user-workload-monitoring is misconfigured. ${REASON}. Please review your configuration according to https://docs.openshift.com/rosa/monitoring/configuring-the-monitoring-stack.html .",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/configuring-the-monitoring-stack"],
   "internal_only": false
 }

--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Platform protections removed by non-Red Hat user",
   "description": "A user on your system has removed a platform protection webhook. This protection has already been automatically replaced, and no further action is required. Tampering with platform protections can endanger SLAs.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "sop_SplunkNonSystemChangeValidatingWebhookConfigurations",

--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: review platform webhook configurations",
     "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, please consult: https://docs.openshift.com/container-platform/latest/architecture/admission-plug-ins.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-admission-plug-ins"],
     "internal_only": false
 }

--- a/osd/workernode_overloaded.json
+++ b/osd/workernode_overloaded.json
@@ -1,7 +1,9 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "capacity-management",
     "summary": "Action required: Cluster health impacted by missing resource limits",
     "description" : "Your cluster requires you to take action. One or more of your cluster's worker nodes do not have enough resources to run critical components. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-clusters#nodes-cluster-limit-ranges"],
     "internal_only": false
 }

--- a/osd/workernode_overloaded_pid_limit_rosa.json
+++ b/osd/workernode_overloaded_pid_limit_rosa.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
     "summary": "Action required: Cluster health impacted by High Pod PID Limits",
     "description" : "Your cluster requires you to take action. SRE has detected that due to a high Pod PID Limit setting, one or more of your cluster's worker nodes are experiencing PID exhaustion preventing them from running critical workloads. As a result, your cluster's operation may be impaired. Please lower the Pod PID Limits to avoid overcommitting the worker nodes, and consider either reducing application process usage or increasing the size of or number of your worker nodes. For more information on capacity planning, please see https://docs.openshift.com/rosa/rosa_planning/rosa-planning-environment.html.",
     "internal_only": false

--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -1,8 +1,10 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
   "summary": "Action required: Fix workload deployed in a restricted project",
   "description": "Your cluster requires you to take action. The workload '${CUSTOMER_WORKLOAD}' has been deployed in the '${RESTRICTED_PROJECT}' project  which is a reserved project for cluster's infrastructure components. Other components are unlikely to function properly in this reserved project and should be installed to a different one. Please refer to https://docs.openshift.com/dedicated/support/troubleshooting/osd-managed-resources.html to learn more about restricted projects.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"],
   "internal_only": false,
   "_tags": [
     "sop_PodDisruptionBudgetLimit",


### PR DESCRIPTION
This PR aims to add required attributes (severity, log type and doc references) as per https://issues.redhat.com/browse/OCM-3685 for all osd managed-notifications.

All remaining managed-notifications (in context to cluster, hcp and ocm) will be covered in https://issues.redhat.com/browse/OSD-19763

Please refer [SDE-3653](https://issues.redhat.com//browse/SDE-3653) and [OSD-19762](https://issues.redhat.com//browse/OSD-19762) for more information.