### PR TITLE
OSD-19763: Added correct attributes to hcp, ocm and cluster managed notifications

### DIFF
--- a/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
+++ b/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Cluster uninstall left behind PersistentVolume(s)",
     "description": "The PersistentVolumeClaim(s) ${CLAIMS} with StorageClass ${STORAGECLASS} have been left behind after your ROSA HCP cluster's uninstall. It is safe to delete them if they are no longer needed for your workloads.",
     "internal_only": false

--- a/hcp/WorkerNodes_Provisioning_error.json
+++ b/hcp/WorkerNodes_Provisioning_error.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
     "summary": "Worker node provisioning, action required",
     "description": "Your cluster's worker nodes are unable to provision due to ${REASON}. Please remediate the issue by ${REMEDIATION}.",
     "internal_only": false

--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -1,6 +1,7 @@
 {
     "severity": "Error",
     "service_name": "SREManualAction",
+    "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",
     "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support case with Red Hat to nominate a new owner for the cluster in https://cloud.redhat.com/openshift/.",
     "internal_only": false


### PR DESCRIPTION
This PR adds attributes to managed notifications in context to cluster, hcp, and ocm as mentioned in [OSD-19763](https://issues.redhat.com/browse/OSD-19763)

This is for the epic Worker Node Utilization Alerting - M2: [SDE-3653](https://issues.redhat.com//browse/SDE-3653)