### PR TITLE
Adding SL for worker nodes stopped manually in DataPlane for Hosted clusters

### DIFF
--- a/hcp/WorkerNodes_Stopped_error.json
+++ b/hcp/WorkerNodes_Stopped_error.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
+    "summary": "Worker node(s) stopped, action required",
+    "description": "Your cluster's worker nodes are stopped due to manual action in AWS which is not supported. Please remediate the issue by starting the instances again. If you would like to change the number of worker instances, please refer documentation https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-scaling-worker-nodes_rosa-managing-worker-nodes.",
+    "internal_only": false
+}

--- a/hcp/WorkerNodes_Stopped_error.json
+++ b/hcp/WorkerNodes_Stopped_error.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Worker node(s) stopped, action required",
-    "description": "Your cluster's worker nodes are stopped due to manual action in AWS which is not supported. Please remediate the issue by starting the instances again. If you would like to change the number of worker instances, please refer documentation https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-scaling-worker-nodes_rosa-managing-worker-nodes.",
+    "description": "Your cluster's worker nodes are stopped due to manual action in AWS which is not supported. Please remediate the issue by starting the instances again. If you would like to change the number of worker instances, please refer to the documentation https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-scaling-worker-nodes_rosa-managing-worker-nodes.",
     "internal_only": false
 }


### PR DESCRIPTION
This SL regards the scenario where customer manually stops AWS instances from AWS console for a Hosted cluster and that triggers ClusterMetricsMissing alert. The SL is notifying customer about starting the instances again and modifying the MachinePool from OCM console if required instead. The recommendation was tested in staging HCP cluster and it works as expected.