### PR TITLE
Update incident service logs

### DIFF
--- a/osd/incident_declared.json
+++ b/osd/incident_declared.json
@@ -2,7 +2,6 @@
   "event_stream_id": "${INCIDENT_ID}",
   "severity": "Error",
   "service_name": "SREManualAction",
-  "log_type": "cluster-configuration",
   "summary": "Cluster incident identified",
   "description": "Your cluster is identified to have a failure that is currently under investigation. The initial issue can be described as '${BRIEF_DESCRIPTION}'.",
   "internal_only": false,

--- a/osd/incident_declared.json
+++ b/osd/incident_declared.json
@@ -1,0 +1,10 @@
+{
+  "event_stream_id": "${INCIDENT_ID}",
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Cluster incident identified",
+  "description": "Your cluster is identified to have a failure that is currently under investigation. The initial issue can be described as '${BRIEF_DESCRIPTION}'.",
+  "internal_only": false,
+  "_tags": []
+}

--- a/osd/incident_resolved.json
+++ b/osd/incident_resolved.json
@@ -1,9 +1,10 @@
 {
+  "event_stream_id": "${INCIDENT_ID}",
   "severity": "Info",
   "service_name": "SREManualAction",
   "log_type": "customer-support",
   "summary": "Cluster incident resolved",
-  "description": "cluster incident '${ALERT_NAME}' is resolved.",
+  "description": "Cluster incident is resolved.",
   "internal_only": false,
   "_tags": [
     "sop_KubeControllerManagerCrashloopingSRE"

--- a/osd/incident_resolved.json
+++ b/osd/incident_resolved.json
@@ -2,7 +2,6 @@
   "event_stream_id": "${INCIDENT_ID}",
   "severity": "Info",
   "service_name": "SREManualAction",
-  "log_type": "customer-support",
   "summary": "Cluster incident resolved",
   "description": "Cluster incident is resolved.",
   "internal_only": false,

--- a/osd/incident_update.json
+++ b/osd/incident_update.json
@@ -1,0 +1,10 @@
+{
+  "event_stream_id": "${INCIDENT_ID}",
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "log_type": "customer-support",
+  "summary": "Cluster incident update",
+  "description": "${INCIDENT_UPDATE_MESSAGE}. Please refer to support case ${CASE_ID} for communication with our team, where there is opportunity for ongoing dialogue.",
+  "internal_only": false,
+  "_tags": []
+}

--- a/osd/incident_update.json
+++ b/osd/incident_update.json
@@ -2,7 +2,6 @@
   "event_stream_id": "${INCIDENT_ID}",
   "severity": "Info",
   "service_name": "SREManualAction",
-  "log_type": "customer-support",
   "summary": "Cluster incident update",
   "description": "${INCIDENT_UPDATE_MESSAGE}. Please refer to support case ${CASE_ID} for communication with our team, where there is opportunity for ongoing dialogue.",
   "internal_only": false,


### PR DESCRIPTION
This change modifies the service logs to more closely align with what we currently have in WebRCA as well as address concerns with the incident ID not making sense to external customers. More on that conversation here:
https://redhat-internal.slack.com/archives/C03M8A471V1/p1704922462075899?thread_ts=1704899958.904489&cid=C03M8A471V1.

I also add an open-ended SL for sending updates to the customer. Often this is handled by MCS in a separate proactive case, but I believe this would still be useful.

[OSDEV-1386](https://issues.redhat.com//browse/OSDEV-1386)