### PR TITLE
fix link for invalid subnet SL

### DIFF
--- a/osd/aws/InstallFailed_InvalidSubnet.json
+++ b/osd/aws/InstallFailed_InvalidSubnet.json
@@ -3,6 +3,6 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations.",
+  "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 4: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installation-config-parameters-aws.html#installation-configuration-parameters-optional-aws_installation-config-parameters-aws.",
   "internal_only": false
 }

--- a/osd/aws/InstallFailed_STS_PrivateLink.json
+++ b/osd/aws/InstallFailed_STS_PrivateLink.json
@@ -3,6 +3,6 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 3: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations.",
+  "description": "Your cluster's installation was blocked by an invalid subnet selection error. The error was: '${HIVE_INSTALL_ERROR}' Please check the subnets provided in the platform.aws.subnets parameter during installation. AWS VPC/Subnet requirements are described in this document, Table 4: Optional AWS Parameters - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installation-config-parameters-aws.html#installation-configuration-parameters-optional-aws_installation-config-parameters-aws.",
   "internal_only": false
 }


### PR DESCRIPTION
This came out of reviewing doc links for existing service logs in partnership with the rosa docs team. Fixing the old link in this SL. The table doesnt exist anymore.