### PR TITLE
remove efs operator service log as it is no longer supported

### DIFF
--- a/osd/aws/MultipleVersionsOfEFSOperatorInstalled.json
+++ b/osd/aws/MultipleVersionsOfEFSOperatorInstalled.json
@@ -1,9 +1,0 @@
-{
-    "severity": "Info",
-    "service_name": "SREManualAction",
-    "log_type": "cluster-configuration",
-    "summary": "Multiple versions of EFS CSI driver installed on cluster",
-    "description": "Red Hat has detected that your cluster is running multiple versions of EFS CSI driver. This configuration is not safe to use as this might lead to the EFS Operator not working as expected. Please use the officially supported version of EFS operator as described in https://access.redhat.com/solutions/4591701.",
-    "doc_references": ["https://access.redhat.com/solutions/4591701"],
-    "internal_only": false
-}


### PR DESCRIPTION
As per https://access.redhat.com/articles/5025181 aws efs operator is no longer an SRE supported operator in OSd/ROSA. It was only available until 4.10 which has alraedy reached EOL:  https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html

Removing this SOP to clean up.