### PR TITLE
Expanding EIP acronym to Elastic IP

### DIFF
--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked on AWS AddressLimitExceeded error. Please raise the EIP addresses quota or remove some EIP addresses for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
+    "description": "Your cluster's installation is blocked on AWS AddressLimitExceeded error. Please raise the Elastic IP addresses quota or remove some Elastic IP addresses for the installation to succeed. AWS account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account.",
     "doc_referneces": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/monitoring/managing-alerts#expiring-silences_managing-alerts"],
     "internal_only": false
 }


### PR DESCRIPTION
EIP is not a common enough acronym to get away with not expanding it on first use, and since there are only two uses I've expanded both.