### PR TITLE
Add missing OIDC SL for HCP

### DIFF
--- a/hcp/sts_deleted_provider.json
+++ b/hcp/sts_deleted_provider.json
@@ -1,0 +1,9 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Action required: Review OpenIDConnect provider configuration",
+  "description": "Your cluster requires you to take action because the OpenIDConnect provider for this cluster could not be found. Please revert any changes to the OIDC provider to maintain ongoing cluster support.",
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly"],
+  "internal_only": false
+}


### PR DESCRIPTION
Mirror https://github.com/openshift/managed-notifications/blob/d11a4b38da574bdc368848a7bd47760d65c63166/osd/aws/sts_deleted_provider.json for HCP.
Same message but a different document URL for HCP. 