### PR TITLE
Remove duplicate _tags and update SOP backrefs

### DIFF
--- a/osd/User_Forbidden.json
+++ b/osd/User_Forbidden.json
@@ -6,7 +6,6 @@
   "description": "The Red Hat Site Reliability Engineering (SRE) team detected a security event on your Managed OpenShift cluster. There are an elevated number of API calls that failed authorization for the following users on your cluster: ${USERNAME}. Because the users belong to your organization, Red Hat SRE is sending this notice to you for further analysis.",
   "internal_only": false,
   "_tags": [
-    "sop_SplunkUserForbidden",
     "sop_SplunkUserForbidden"
   ]
 }

--- a/osd/aws/InstallFailed_InvalidCustomTag.json
+++ b/osd/aws/InstallFailed_InvalidCustomTag.json
@@ -1,13 +1,11 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "log_type" : "cluster-lifecycle",
-    "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to an invalid user-defined tag. The tag provided for the cluster install with the key '${KEY}' is not allowed. Please change or remove the invalid tag and try re-installing the cluster.",
-    "internal_only": false,
-    "_tags": [
-      "t_install",
-      "sop_ClusterProvisioningFailure"
-    ]
-  }
-
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation is blocked due to an invalid user-defined tag. The tag provided for the cluster install with the key '${KEY}' is not allowed. Please change or remove the invalid tag and try re-installing the cluster.",
+  "internal_only": false,
+  "_tags": [
+    "t_install"
+  ]
+}

--- a/osd/aws/ROSA_AWS_KMS_permissions_required.json
+++ b/osd/aws/ROSA_AWS_KMS_permissions_required.json
@@ -1,9 +1,14 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "log_type": "cluster-lifecycle",
-    "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to missing or insufficient privileges required by ROSA to access/use the customer-managed KMS key that has been supplied for encrypting instances. Please ensure that the appropriate IAM permissions are granted to the ManagedOpenShift roles to allow use of the key. For more information, please review the documentation: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations"],
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-lifecycle",
+  "summary": "Installation blocked, action required",
+  "description": "Your cluster's installation is blocked due to missing or insufficient privileges required by ROSA to access/use the customer-managed KMS key that has been supplied for encrypting instances. Please ensure that the appropriate IAM permissions are granted to the ManagedOpenShift roles to allow use of the key. For more information, please review the documentation: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations.",
+  "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations"
+  ],
+  "_tags": [
+    "sop_ClusterMetricsMissing"
+  ]
 }

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -4,11 +4,12 @@
   "log_type": "cluster-networking",
   "summary": "Action required: Cluster proxy CA Expiring",
   "description": "Your cluster requires you to take action because one of the Certificate Authority (CA) certificates in the Additional Trusted CA Bundle you have set for your cluster will not be valid after ${DATE}: ${CA_SUBJECT}. To avoid any potential disruption of service or cluster availability caused by the expiration of the CA certificate, please ensure your Additional Trusted CA Bundle is updated with any new CA certificates required.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy"
+  ],
   "_tags": [
     "t_network",
-    "sop_ClusterProxyCAExpiringSRE",
     "sop_ClusterProxyCAExpiringSRE"
   ]
 }

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -1,13 +1,14 @@
 {
   "severity": "Error",
   "service_name": "SREManualAction",
-  "summary": "Cluster destroyed, cannot be recovered",
   "log_type": "cluster-lifecycle",
+  "summary": "Cluster destroyed, cannot be recovered",
   "description": "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/osd_quickstart/osd-quickstart.html#deleting-cluster_osd-getting-started.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"
+  ],
   "_tags": [
-    "sop_cluster_has_gone_missing",
     "sop_cluster_has_gone_missing"
   ]
 }

--- a/osd/cluster_has_gone_missing.json
+++ b/osd/cluster_has_gone_missing.json
@@ -4,11 +4,11 @@
   "log_type": "cluster-configuration",
   "summary": "Action required: cluster not checking in",
   "description": "Your cluster requires you to take action because it is no longer checking in with Red Hat OpenShift Cluster Manager. Possible causes include stopping instances or a networking misconfiguration. If you have stopped the cluster instances, please start them again - stopping instances is not supported. If you intended to terminate this cluster then please delete the cluster in the Red Hat console.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#doc-wrapper"
+  ],
   "_tags": [
-    "sop_cluster_has_gone_missing",
-    "sop_cluster_has_gone_missing",
     "sop_cluster_has_gone_missing"
   ]
 }

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -2,8 +2,11 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
-  "_tags": ["t_config"],
   "summary": "Action required: Unsupported change to worker node instances",
   "description": "Your cluster requires you to take action because an unsupported change to worker node(s) has been observed on your cluster: ${CHANGE}. Without action, your cluster's SLA may be impacted. ${REMEDIATION}.",
-  "internal_only": false
+  "internal_only": false,
+  "_tags": [
+    "t_config",
+    "sop_ClusterMetricsMissing"
+  ]
 }

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -4,11 +4,12 @@
   "log_type": "cluster-configuration",
   "summary": "Action required: Restore missing cloud credentials",
   "description": "Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/install_rosa_classic_clusters/index#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/install_rosa_classic_clusters/index#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly"
+  ],
   "_tags": [
     "t_config",
-    "sop_cluster_has_gone_missing",
     "sop_cluster_has_gone_missing"
   ]
 }

--- a/osd/rosa_customer_pdb_preventing_drain.json
+++ b/osd/rosa_customer_pdb_preventing_drain.json
@@ -1,13 +1,11 @@
-{  
+{
   "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",
   "description": "Your cluster is attempting to drain node `${NODE}` but there is a pod disruption budget set that is preventing the drain. The OSD SRE team has identified the pod as `${POD}` running in the namespace: `${NAMESPACE}`. Please re-schedule this pod so that the node can drain. For more information on pod disruption budgets please see https://docs.openshift.com/rosa/nodes/pods/nodes-pods-configuring.html.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"],
   "internal_only": false,
-  "_tags": [
-    "sop_KubeNodeUnschedulableSRE",
-    "sop_MCDDrainError"
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
   ]
 }

--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -4,10 +4,11 @@
   "log_type": "cluster-configuration",
   "summary": "Platform protections removed by non-Red Hat user",
   "description": "A user on your system has removed a platform protection webhook. This protection has already been automatically replaced, and no further action is required. Tampering with platform protections can endanger SLAs.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"
+  ],
   "_tags": [
-    "sop_SplunkNonSystemChangeValidatingWebhookConfigurations",
     "sop_SplunkNonSystemChangeValidatingWebhookConfigurations"
   ]
 }

--- a/osd/workernode_overloaded.json
+++ b/osd/workernode_overloaded.json
@@ -1,9 +1,14 @@
 {
-    "severity": "Error",
-    "service_name": "SREManualAction",
-    "log_type": "capacity-management",
-    "summary": "Action required: Cluster health impacted by missing resource limits",
-    "description" : "Your cluster requires you to take action. One or more of your cluster's worker nodes do not have enough resources to run critical components. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-clusters#nodes-cluster-limit-ranges"],
-    "internal_only": false
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "capacity-management",
+  "summary": "Action required: Cluster health impacted by missing resource limits",
+  "description": "Your cluster requires you to take action. One or more of your cluster's worker nodes do not have enough resources to run critical components. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.",
+  "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-clusters#nodes-cluster-limit-ranges"
+  ],
+  "_tags": [
+    "sop_ClusterMetricsMissing"
+  ]
 }

--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -4,11 +4,11 @@
   "log_type": "cluster-configuration",
   "summary": "Action required: Fix workload deployed in a restricted project",
   "description": "Your cluster requires you to take action. The workload '${CUSTOMER_WORKLOAD}' has been deployed in the '${RESTRICTED_PROJECT}' project  which is a reserved project for cluster's infrastructure components. Other components are unlikely to function properly in this reserved project and should be installed to a different one. Please refer to https://docs.openshift.com/dedicated/support/troubleshooting/osd-managed-resources.html to learn more about restricted projects.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"],
   "internal_only": false,
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-managed-resources#doc-wrapper"
+  ],
   "_tags": [
-    "sop_PodDisruptionBudgetLimit",
     "sop_PodDisruptionBudgetLimit"
   ]
-
 }


### PR DESCRIPTION
This change removes duplicate SOP backreferences in _tags and applies some programmatic formatting. The code to do this can be found here: https://github.com/geowa4/servicelogger/pull/27.

[OSD-21264](https://issues.redhat.com//browse/OSD-21264)