### PR TITLE
Fixed broken links

### DIFF
--- a/osd/aws/InstallFailed_CreateServiceLinkedRole.json
+++ b/osd/aws/InstallFailed_CreateServiceLinkedRole.json
@@ -3,7 +3,7 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",
-  "description": "Your cluster's installation was blocked because the ELB Service Role does not exist. In AWS accounts that have never created a load balancer before, it is possible that the service role for ELB might not exist yet. Please refer to the troubleshooting doc: 'https://docs.openshift.com/rosa/rosa_support/rosa-troubleshooting-deployments.html#rosa-troubleshooting-elb-serivce-role_rosa-troubleshooting-cluster-deployments'.",
+  "description": "Your cluster's installation was blocked because the ELB Service Role does not exist. In AWS accounts that have never created a load balancer before, it is possible that the service role for ELB might not exist yet. Please refer to this documentation: https://docs.openshift.com/rosa/support/troubleshooting/rosa-troubleshooting-deployments.html#rosa-troubleshooting-elb-service-role_rosa-troubleshooting-cluster-deployments.",
   "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/troubleshooting/rosa-troubleshooting-cluster-deployments#rosa-troubleshooting-elb-service-role_rosa-troubleshooting-cluster-deployments"],
   "internal_only": false
 }

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster Logging configuration",
-    "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation via 'Verification steps' section mentioned in doc: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_logging/rosa-install-logging.html.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/cluster-logging-deploying"],
+    "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation using the 'Verification' sections of this documentation: https://docs.openshift.com/rosa/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/cluster-logging"],
     "internal_only": false
 }


### PR DESCRIPTION
The link-checking CI job, while useful, is unfortunately holding up several other PRs (as it checks the whole repo, not just the files touched by each PR). This PR temporarily mitigates this by fixing the broken links mentioned in the [latest CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_managed-notifications/287/pull-ci-openshift-managed-notifications-master-checklinks-pr/1762990565722427392).