### PR TITLE
Add proxy HTTPS malfunction SL

### DIFF
--- a/osd/aws/InstallFailed_ProxyBadTLS.json
+++ b/osd/aws/InstallFailed_ProxyBadTLS.json
@@ -1,0 +1,11 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "summary": "Installation blocked: Proxy malfunction",
+  "description": "Your cluster's installation is blocked because the configured cluster-wide proxy is not properly initiating TLS handshakes for HTTPS connections. Please review your network and proxy configuration and retry cluster installation. Please refer to the following documentation on cluster-wide proxies: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#.",
+  "log_type": "cluster-networking",
+  "_tags": ["t_network", "t_install", "sop_ClusterProvisioningFailure"],
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#configuring-a-cluster-wide-proxy"],
+  "internal_only": false,
+  "event_stream_id": ""
+}

--- a/osd/aws/InstallFailed_ProxyBadTLS.json
+++ b/osd/aws/InstallFailed_ProxyBadTLS.json
@@ -2,7 +2,7 @@
   "severity": "Error",
   "service_name": "SREManualAction",
   "summary": "Installation blocked: Proxy malfunction",
-  "description": "Your cluster's installation is blocked because the configured cluster-wide proxy is not properly initiating TLS handshakes for HTTPS connections. Please review your network and proxy configuration and retry cluster installation. Please refer to the following documentation on cluster-wide proxies: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#.",
+  "description": "Your cluster's installation is blocked because the configured cluster-wide proxy is not properly initiating TLS handshakes for HTTPS connections. Please review your network and proxy configuration and retry cluster installation. Seet the following documentation for more details on cluster-wide proxies: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#.",
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_install", "sop_ClusterProvisioningFailure"],
   "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#configuring-a-cluster-wide-proxy"],


### PR DESCRIPTION
This PR adds a new "Installation blocked" service log to cover cases where a customer's proxy is not properly handling HTTPS connections due to bad TLS handshakes. This is usually evidenced by errors like "proxyconnect tcp: tls: first record does not look like a TLS handshake" being emitted by curl or osd-network-verifier.