### PR TITLE
Fix link to custom domain documentation

### DIFF
--- a/osd/custom_domain_cert_misconfiguration.json
+++ b/osd/custom_domain_cert_misconfiguration.json
@@ -5,6 +5,6 @@
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: update custom domain configuration",
   "description": "The custom application domain '${CUSTOM_DOMAIN}' has a malformed or misconfigured certificate. Please review the certificate provided by the '${SECRET}' secret in the '${SECRET_NS}' namespace to restore functionality to your cluster. For additional information on custom-domains-operator, refer to the following documentation: https://access.redhat.com/articles/5599621.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-applications-renew-custom-domains_osd-config-custom-domains-applications"],
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/applications/deployments#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications"],
   "internal_only": false
 }

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -4,7 +4,7 @@
   "log_type": "cluster-networking",
   "summary": "Action required: update custom domain configuration",
   "description": "The custom application domain '${CUSTOM_DOMAIN}' is misconfigured, generating alerts to Red Hat SRE. Please review it to restore the cluster's operation. Please do not use reserved names: \"apps\", \"apps2\", or \"default\". See documentation: https://access.redhat.com/articles/5599621.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/applications/deployments#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications"],
   "internal_only": false,
   "_tags": [
     "t_network",

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -5,6 +5,6 @@
   "_tags": ["t_network"],
   "summary": "Invalid TLS certificate",
   "description": "Your cluster uses an invalid TLS certificate that is signed by an unknown authority. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
+  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/applications/deployments#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications"],
   "internal_only": false
 }

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -4,6 +4,6 @@
     "log_type": "cluster-networking",
     "summary": "Invalid TLS certificate",
     "description": "Your cluster uses an invalid TLS certificate. Invalid TLS certificates result in failing requests to applications deployed to the cluster (for example the OpenShift Console) and will impact Red Hat's ability to monitor and support your cluster. To use a custom domain please follow the documentation on setting up custom application domains at https://access.redhat.com/articles/5599621.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/application_development/deployments#osd-config-custom-domains-applications"],
+    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/applications/deployments#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications"],
     "internal_only": false
 }


### PR DESCRIPTION
Links were returning 404. This fixes the references in four different SL templates