### PR TITLE
Update the url used for cluster_owner_disabled template

### DIFF
--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -3,6 +3,6 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",
-    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support case with Red Hat to nominate a new owner for the cluster in https://cloud.redhat.com/openshift/.",
+    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support case with Red Hat to nominate a new owner for the cluster in https://console.redhat.com/openshift/.",
     "internal_only": false
 }


### PR DESCRIPTION
The old url cloud.redhat.com/openshift redirects to console.redhat.com/openshift.

```
$ curl -I https://cloud.redhat.com/openshift
HTTP/2 302 
...
location: https://console.redhat.com/openshift
...
```