### PR TITLE
Ensure GCP service logs do not link to ROSA/AWS docs

### DIFF
--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",
-    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-requirements_gcp-ccs.",
+    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account requirements are described in this document: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-requirements_gcp-ccs.",
     "doc_references": ["https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"],
     "internal_only": false
 }

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",
-    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-required-aws-service-quotas"],
+    "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account limits are described in this document: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-requirements_gcp-ccs.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"],
     "internal_only": false
 }

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -3,6 +3,9 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account limits are described in this document - https://docs.openshift.com/container-platform/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account.",
-    "internal_only": false
+    "description": "Your cluster's installation is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the quota or free enough resources for the installation to succeed. GCP account requirements are described in this document: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-requirements_gcp-ccs.",
+    "internal_only": false,
+    "doc_references": [
+      "https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"
+    ]
 }

--- a/osd/gcp/invalid_iaas_credentials.json
+++ b/osd/gcp/invalid_iaas_credentials.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Restore missing cloud credentials",
-    "description": "Your cluster requires you to take action because Red Hat SRE is not able to access the cloud provider infrastructure with the provided credentials in order to support your cluster. Please restore the credentials and permissions provided during install. For more information on the IAM roles and accesses required, please refer to the documentation available at: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/install_rosa_classic_clusters/index#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly"],
+    "description": "Your cluster requires you to take action because Red Hat SRE is not able to access the cloud provider infrastructure with the provided credentials in order to support your cluster. Please restore the credentials and permissions provided during install. For more information on the IAM roles and accesses required, please refer to the documentation available at: https://docs.openshift.com/dedicated/osd_planning/gcp-ccs.html#ccs-gcp-customer-requirements_gcp-ccs.",
+    "doc_references": ["https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"],
     "internal_only": false
 }


### PR DESCRIPTION
The "invalid credentials" and "quota exceeded" SLs for GCP contained links to AWS/ROSA docs. This PR corrects those links such that they point to OSD-on-GCP docs.