### PR TITLE
Added a  LokiStack specific general logging servicelog 

### DIFF
--- a/osd/KubePersistentVolumeFillingUp-customer-namespace.json
+++ b/osd/KubePersistentVolumeFillingUp-customer-namespace.json
@@ -1,9 +1,0 @@
-
-{
-    "severity": "Warning",
-    "service_name": "SREManualAction",
-    "cluster_uuid": "${CLUSTER_UUID}",
-    "summary": "Action required: update cluster monitoring configuration in ${NAMESPACE}",
-    "description": "Based on recent sampling, the PersistentVolume claimed by ${PVC} in Namespace ${NAMESPACE} is expected to fill up within ${DAYS} days. Currently ${PERCENT}% is available.SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",
-    "internal_only": false
-}

--- a/osd/KubePersistentVolumeFillingUp-customer-namespace.json
+++ b/osd/KubePersistentVolumeFillingUp-customer-namespace.json
@@ -1,0 +1,9 @@
+
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "cluster_uuid": "${CLUSTER_UUID}",
+    "summary": "Action required: update cluster monitoring configuration in ${NAMESPACE}",
+    "description": "Based on recent sampling, the PersistentVolume claimed by ${PVC} in Namespace ${NAMESPACE} is expected to fill up within ${DAYS} days. Currently ${PERCENT}% is available.SRE recommends reducing application logging on your cluster to ensure logging continues to function smoothly in the future.",
+    "internal_only": false
+}

--- a/osd/rosa_clusterlogging_loki.json
+++ b/osd/rosa_clusterlogging_loki.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
+    "summary": "Action required: Update Cluster LokiStack Logging configuration",
+    "description": "Your cluster requires you to take action. Your cluster has problems on the Cluster Logging service. Please verify your logging installation by following the documented Verification steps: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/logging/cluster-logging-deploying#.",
+    "doc_references": ["https://docs.openshift.com/container-platform/4.15/logging/log_storage/cluster-logging-loki.html","https://docs.openshift.com/container-platform/4.15/logging/log_storage/cluster-logging-loki.html"],
+    "internal_only": false
+}


### PR DESCRIPTION
In this commit, I added a  general logging servicelog with documentation https://docs.openshift.com/container-platform/4.15/logging/log_storage/cluster-logging-loki.html specific for Configuring the LokiStack log store.