### PR TITLE
First pass at updating all severities to align with OCM

### DIFF
--- a/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
+++ b/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster uninstall left behind PersistentVolume(s)",

--- a/hcp/WorkerNodes_Provisioning_error.json
+++ b/hcp/WorkerNodes_Provisioning_error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Worker node provisioning, action required",

--- a/hcp/WorkerNodes_Stopped_error.json
+++ b/hcp/WorkerNodes_Stopped_error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Worker node(s) stopped, action required",

--- a/hcp/sts_deleted_provider.json
+++ b/hcp/sts_deleted_provider.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review OpenIDConnect provider configuration",

--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",

--- a/osd/AddonMisconfiguration.json
+++ b/osd/AddonMisconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "_tags": ["t_config"],

--- a/osd/AllowedSourceRanges.json
+++ b/osd/AllowedSourceRanges.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Incorrect Default IngressController Configuration",

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Bad MachineConfigPool Configuration",

--- a/osd/BadMachinePoolTaint.json
+++ b/osd/BadMachinePoolTaint.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Incorrect MachinePool Configuration",

--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "_tags": ["t_network"],

--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: review cluster logging configuration",

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Elasticsearch impacted by cluster resource limits",

--- a/osd/ElasticsearchClusterNotHealthy_Error.json
+++ b/osd/ElasticsearchClusterNotHealthy_Error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",

--- a/osd/ElasticsearchClusterNotHealthy_Warning.json
+++ b/osd/ElasticsearchClusterNotHealthy_Warning.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "_tags": ["t_network", "t_config"],

--- a/osd/KubePersistentVolumeFillingUpError-user.json
+++ b/osd/KubePersistentVolumeFillingUpError-user.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Persistent Volume filling",

--- a/osd/KubePersistentVolumeFillingUpError.json
+++ b/osd/KubePersistentVolumeFillingUpError.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Urgent action required: update cluster logging configuration",

--- a/osd/KubePersistentVolumeFillingUpWarn.json
+++ b/osd/KubePersistentVolumeFillingUpWarn.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: update cluster logging configuration",

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Multiple Default Storage Classes Configured",

--- a/osd/Multiple_OCPBUGs_install_failure.json
+++ b/osd/Multiple_OCPBUGs_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_config", "t_network"],

--- a/osd/NetworkMisconfiguration_WithDoc.json
+++ b/osd/NetworkMisconfiguration_WithDoc.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/NodeFileDescriptorLimit_worker.json
+++ b/osd/NodeFileDescriptorLimit_worker.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "capacity-management",
   "summary": "Action required: Worker node file descriptor limit nearly exhausted",

--- a/osd/NodeFilesystemSpaceFillingUp-worker.json
+++ b/osd/NodeFilesystemSpaceFillingUp-worker.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "capacity-management",
   "summary": "Action required: Worker node mountpoint space nearly exhausted",

--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-security",
   "summary": "Non-Red Hat Access Core Secrets",

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "OCM3018 Installation blocked, action required",

--- a/osd/OCPBUGS6494_4_12_install_failure.json
+++ b/osd/OCPBUGS6494_4_12_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/OCPBUG_install_failure.json
+++ b/osd/OCPBUG_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "_tags": ["t_config"],

--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Platform component accessed by non-Red Hat SRE user",

--- a/osd/PodSecurityPolicy_conflict.json
+++ b/osd/PodSecurityPolicy_conflict.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/RHOAMInstallNeedsMoreResources.json
+++ b/osd/RHOAMInstallNeedsMoreResources.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "summary": "Action required: Add resources to complete RHOAM installation",

--- a/osd/RecoveryOfDeletedMaster.json
+++ b/osd/RecoveryOfDeletedMaster.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Recovery of deleted master nodes is not supported",

--- a/osd/ResourceIsRaisingClusterAlert.json
+++ b/osd/ResourceIsRaisingClusterAlert.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is triggering a alert",

--- a/osd/ResourceQuotaOpenshiftNamespace.json
+++ b/osd/ResourceQuotaOpenshiftNamespace.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Installed ServiceQuotas in openshift namespaces breaks cluster operation",

--- a/osd/ReviewServiceControlPolicy.json
+++ b/osd/ReviewServiceControlPolicy.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action required: Review Service Control Policy",

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation failed (invalid IAM roles)",

--- a/osd/StuckNewBuilds3MinSRE.json
+++ b/osd/StuckNewBuilds3MinSRE.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: update cluster build configuration",

--- a/osd/additional_trusted_ca_missing.json
+++ b/osd/additional_trusted_ca_missing.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/aws/AWS_outage.json
+++ b/osd/aws/AWS_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "AWS Outage Impacting Your Cluster",

--- a/osd/aws/AWS_zone_outage.json
+++ b/osd/aws/AWS_zone_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "AWS Availability Zone Outage Impacting Your Cluster",

--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/AlertmanagerSilencesActiveSRE.json
+++ b/osd/aws/AlertmanagerSilencesActiveSRE.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Clear Alertmanager Silences",

--- a/osd/aws/ClusterGoneMissing_NetworkIssue
+++ b/osd/aws/ClusterGoneMissing_NetworkIssue
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: review firewall configuration",

--- a/osd/aws/ELBDeleted.json
+++ b/osd/aws/ELBDeleted.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-networking",
     "summary": "Cluster Operators degraded",

--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",

--- a/osd/aws/GenericResourceDeleted.json
+++ b/osd/aws/GenericResourceDeleted.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Critical AWS Resource Has Been Deleted",

--- a/osd/aws/InstallFailed_AWSS3Change.json
+++ b/osd/aws/InstallFailed_AWSS3Change.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",

--- a/osd/aws/InstallFailed_AWS_Capacity.json
+++ b/osd/aws/InstallFailed_AWS_Capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
+++ b/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_CreateServiceLinkedRole.json
+++ b/osd/aws/InstallFailed_CreateServiceLinkedRole.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InsufficientPermissions.json
+++ b/osd/aws/InstallFailed_InsufficientPermissions.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidCustomTag.json
+++ b/osd/aws/InstallFailed_InvalidCustomTag.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidDHCPOptionset.json
+++ b/osd/aws/InstallFailed_InvalidDHCPOptionset.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidSubnet.json
+++ b/osd/aws/InstallFailed_InvalidSubnet.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
+++ b/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Duplicate hosted zones",

--- a/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
+++ b/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NoRouteToInternet.json
+++ b/osd/aws/InstallFailed_NoRouteToInternet.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Missing route to internet",

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
+++ b/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_ProxyBadTLS.json
+++ b/osd/aws/InstallFailed_ProxyBadTLS.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "summary": "Installation blocked: Proxy malfunction",
   "description": "Your cluster's installation is blocked because the configured cluster-wide proxy is not properly initiating TLS handshakes for HTTPS connections. Please review your network and proxy configuration and retry cluster installation. Seet the following documentation for more details on cluster-wide proxies: https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#.",

--- a/osd/aws/InstallFailed_QuotaExceeded.json
+++ b/osd/aws/InstallFailed_QuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_RoleDeletionFailed.json
+++ b/osd/aws/InstallFailed_RoleDeletionFailed.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_STS_PrivateLink.json
+++ b/osd/aws/InstallFailed_STS_PrivateLink.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_SecurityGroupBeingModified.json
+++ b/osd/aws/InstallFailed_SecurityGroupBeingModified.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_TempAWSError.json
+++ b/osd/aws/InstallFailed_TempAWSError.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",

--- a/osd/aws/InstallFailed_TooManyBucketObjectTags.json
+++ b/osd/aws/InstallFailed_TooManyBucketObjectTags.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_TooManyBuckets.json
+++ b/osd/aws/InstallFailed_TooManyBuckets.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_lambda_automation_interfering.json
+++ b/osd/aws/InstallFailed_lambda_automation_interfering.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_proxy_unreachable.json
+++ b/osd/aws/InstallFailed_proxy_unreachable.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "summary": "Installation blocked: Missing route to internet",
   "description": "Your cluster's installation is blocked because of the cluster-wide proxy configured is not reachable. Please review the network and proxy configuration before reattempting cluster installation process: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/networking/configuring-a-cluster-wide-proxy.",

--- a/osd/aws/NodeStuckTerminating.json
+++ b/osd/aws/NodeStuckTerminating.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "AWS Delayed Instance Termination",

--- a/osd/aws/ROSA_AWS_KMS_permissions_required.json
+++ b/osd/aws/ROSA_AWS_KMS_permissions_required.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/ROSA_AWS_invalid_permissions.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-access",
     "summary": "Installation blocked, action required",

--- a/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/VPCEndpointLimitExceeded.json
+++ b/osd/aws/VPCEndpointLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/VPCLimitExceeded.json
+++ b/osd/aws/VPCLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/invalid_kms_policy_byok.json
+++ b/osd/aws/invalid_kms_policy_byok.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review KMS policy for master instance role",

--- a/osd/aws/sts_deleted_provider.json
+++ b/osd/aws/sts_deleted_provider.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review OpenIDConnect provider configuration",

--- a/osd/aws/sts_misconfigured_role.json
+++ b/osd/aws/sts_misconfigured_role.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: Fix AWS Role to maintain SRE support",

--- a/osd/aws/sts_thumbprint.json
+++ b/osd/aws/sts_thumbprint.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: update cluster OIDC thumbprint",

--- a/osd/aws/unable_to_create_machines_aws_capacity.json
+++ b/osd/aws/unable_to_create_machines_aws_capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster machine creation blocked, action required",

--- a/osd/bad_scc_priority.json
+++ b/osd/bad_scc_priority.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: Cluster proxy CA Expiring",

--- a/osd/cluster-wide_proxy_unreachable.json
+++ b/osd/cluster-wide_proxy_unreachable.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-networking",
     "_tags": ["t_network"],

--- a/osd/cluster_alerting_with_no_sre_access.json
+++ b/osd/cluster_alerting_with_no_sre_access.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-access",
     "summary": "Attention requested: Cluster account access unavailable",

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/cluster_has_gone_missing.json
+++ b/osd/cluster_has_gone_missing.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: cluster not checking in",

--- a/osd/cluster_has_second_ingress_controller.json
+++ b/osd/cluster_has_second_ingress_controller.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type":"cluster-networking",
   "summary": "Action required: update cluster configuration",

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: update cluster proxy configuration",

--- a/osd/cluster_proxy_missing_cert_authority_osd.json
+++ b/osd/cluster_proxy_missing_cert_authority_osd.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/cluster_proxy_missing_cert_authority_rosa.json
+++ b/osd/cluster_proxy_missing_cert_authority_rosa.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/cluster_stuck.json
+++ b/osd/cluster_stuck.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Action required: Cluster Stuck",

--- a/osd/custom_domain_cert_misconfiguration.json
+++ b/osd/custom_domain_cert_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],

--- a/osd/custom_domain_misconfiguration.json
+++ b/osd/custom_domain_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: update custom domain configuration",

--- a/osd/customer_alert_blocking_upgrade.json
+++ b/osd/customer_alert_blocking_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-updates",
   "summary": "Action required: Cluster Upgrade Blocked",

--- a/osd/customer_clusteroperator_down.json
+++ b/osd/customer_clusteroperator_down.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action required: Remove or address failing cluster operator",

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",
     "summary": "Action required: Pod emptydir storage preventing Node Drain",

--- a/osd/customer_modified_worker_nodes.json
+++ b/osd/customer_modified_worker_nodes.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Unsupported change to worker node instances",

--- a/osd/customer_pdb_preventing_drain.json
+++ b/osd/customer_pdb_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",

--- a/osd/customer_pdb_preventing_drain_automated.json
+++ b/osd/customer_pdb_preventing_drain_automated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Pod Disruption Budget(s) preventing Node Drain",

--- a/osd/customer_pod_preventing_drain.json
+++ b/osd/customer_pod_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod(s) preventing Node Drain",

--- a/osd/customer_pods_preventing_drain_automated.json
+++ b/osd/customer_pods_preventing_drain_automated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Pod(s) preventing Node Drain",

--- a/osd/customer_stopped_control_plane_node.json
+++ b/osd/customer_stopped_control_plane_node.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Action required: Restart control plane node",

--- a/osd/customer_stopped_control_plane_node_rosa.json
+++ b/osd/customer_stopped_control_plane_node_rosa.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Action required: Restart control plane node",

--- a/osd/dns_misconfigration.json
+++ b/osd/dns_misconfigration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: DNS misconfigration",

--- a/osd/failing_api_service.json
+++ b/osd/failing_api_service.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: correct failing API services",

--- a/osd/gcp/GCP_Network_Misconfig.json
+++ b/osd/gcp/GCP_Network_Misconfig.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Action required: Failed Openshift Installation on GCP",

--- a/osd/gcp/GCP_Service_API_Disabled.json
+++ b/osd/gcp/GCP_Service_API_Disabled.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: enable required service APIs",

--- a/osd/gcp/GCP_outage.json
+++ b/osd/gcp/GCP_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "GCP Outage Impacting Your Cluster",

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",

--- a/osd/gcp/InstallFailed_GCP_Capacity.json
+++ b/osd/gcp/InstallFailed_GCP_Capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/gcp/invalid_iaas_credentials.json
+++ b/osd/gcp/invalid_iaas_credentials.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Restore missing cloud credentials",

--- a/osd/generic_customer_support_case_notification.json
+++ b/osd/generic_customer_support_case_notification.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "Action required: Support case ${CASE_ID}",

--- a/osd/generic_deprovision_failed.json
+++ b/osd/generic_deprovision_failed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Deprovision failed, action required",

--- a/osd/generic_install_failed.json
+++ b/osd/generic_install_failed.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/generic_problem_notification.json
+++ b/osd/generic_problem_notification.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "Action required: ${PROBLEM_SUMMARY}",

--- a/osd/hive_migration.json
+++ b/osd/hive_migration.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "${DATE} Upcoming Maintenance: OpenShift Cluster Manager actions will be unavailable during this maintenance",

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_network", "t_config"],

--- a/osd/incident_declared.json
+++ b/osd/incident_declared.json
@@ -1,6 +1,6 @@
 {
   "event_stream_id": "${INCIDENT_ID}",
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "summary": "Cluster incident identified",
   "description": "Your cluster is identified to have a failure that is currently under investigation. The initial issue can be described as '${BRIEF_DESCRIPTION}'.",

--- a/osd/incorrect_PodDisruptionBudget.json
+++ b/osd/incorrect_PodDisruptionBudget.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: Incorrect Pod Disruption Budget configuration",

--- a/osd/install_failed_please_retry
+++ b/osd/install_failed_please_retry
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Installation blocked, action required",

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Restore missing cloud credentials",

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: Fix AWS Role to maintain SRE support",

--- a/osd/limited_support/LimitedSupportCloud.json
+++ b/osd/limited_support/LimitedSupportCloud.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "summary": "Cluster is in Limited Support due to unsupported cloud provider configuration",
     "log_type": "cluster-configuration",
     "details": "${CONFIGURATION}",

--- a/osd/limited_support/LimitedSupportCluster.json
+++ b/osd/limited_support/LimitedSupportCluster.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "log_type": "cluster-configuration",
     "summary": "Cluster is in Limited Support due to unsupported cluster configuration",
     "details": "${CONFIGURATION}",

--- a/osd/limited_support/scheduled_chaos_test.json
+++ b/osd/limited_support/scheduled_chaos_test.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "summary": "Cluster is in Limited Support due to scheduled chaos testing",
     "log_type": "customer-support",
     "details": "Your cluster is in Limited Support due to a scheduled chaos test. Chaos testing includes AZ outage testing, network testing, disaster recovery testing, etc. Once your testing is complete, please reach out to Red Hat Support to resume full-support of your cluster",

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/no_resources_to_run_userworkloadmonitoring.json
+++ b/osd/no_resources_to_run_userworkloadmonitoring.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: User Workload Monitoring impacted by cluster resource limits",

--- a/osd/osd_too_old_upgrade_needed.json
+++ b/osd/osd_too_old_upgrade_needed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action required: Upgrade cluster before ${CUTOFF_DATE}",

--- a/osd/persistentvolume_resized.json
+++ b/osd/persistentvolume_resized.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Persistent Volume/s Resized",

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",

--- a/osd/proxy_url_misconfigured.json
+++ b/osd/proxy_url_misconfigured.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/pull_secret_rotated.json
+++ b/osd/pull_secret_rotated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Info",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster pull secret updated",

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review pull secret",

--- a/osd/recover_master_node_is_required.json
+++ b/osd/recover_master_node_is_required.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster does not have sufficient number of master nodes",

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Warning",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "SRE recovered master nodes",

--- a/osd/registry_access_denied.json
+++ b/osd/registry_access_denied.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: image-registry gets AccessDenied error",

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: Network misconfiguration",

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Installation blocked, action required",

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/rosa_cluster_cannot_be_recovered.json
+++ b/osd/rosa_cluster_cannot_be_recovered.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecyle",
   "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/rosa_cluster_cant_manage_instances.json
+++ b/osd/rosa_cluster_cant_manage_instances.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster degraded, action required",

--- a/osd/rosa_cluster_destroyed_cluster_admin.json
+++ b/osd/rosa_cluster_destroyed_cluster_admin.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster Logging configuration",

--- a/osd/rosa_clusterlogging_loki.json
+++ b/osd/rosa_clusterlogging_loki.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster LokiStack Logging configuration",

--- a/osd/rosa_customer_pdb_preventing_drain.json
+++ b/osd/rosa_customer_pdb_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-networking",
     "summary": "Invalid TLS certificate",

--- a/osd/rosa_no_egress_route.json
+++ b/osd/rosa_no_egress_route.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/rosa_second_monitoring_stack_installed.json
+++ b/osd/rosa_second_monitoring_stack_installed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: remove second monitoring stack",

--- a/osd/security_update_available.json
+++ b/osd/security_update_available.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-security",
     "summary": "Important security update available",

--- a/osd/silence_namespace_alerts_notice.json
+++ b/osd/silence_namespace_alerts_notice.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Info",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "NOTICE: Silencing alerts for 'openshift-*' user namespaces",

--- a/osd/storageclass_modification.json
+++ b/osd/storageclass_modification.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Address storageclass configuration",

--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "_tags": ["t_config"],

--- a/osd/unevictable_workload.json
+++ b/osd/unevictable_workload.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Unevictable workload detected",

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Cluster incident identified",

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/unsupported_workload.json
+++ b/osd/unsupported_workload.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Remove custom workload from control plane/infra nodes",

--- a/osd/update_pull_secret.json
+++ b/osd/update_pull_secret.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Review pull secret",

--- a/osd/upgrade_blocked.json
+++ b/osd/upgrade_blocked.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",

--- a/osd/upgrade_blocked_with_docs.json
+++ b/osd/upgrade_blocked_with_docs.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",

--- a/osd/upgrade_paused_acknowledgement.json
+++ b/osd/upgrade_paused_acknowledgement.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action Required: Cluster upgrade paused, requires acknowledgement",

--- a/osd/user-ca-bundle_invalid.json
+++ b/osd/user-ca-bundle_invalid.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Critical",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: Misconfigured additional Trusted CA bundle",

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Warning",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Platform protections removed by non-Red Hat user",

--- a/osd/webhooks_impacting_cluster_stability.json
+++ b/osd/webhooks_impacting_cluster_stability.json
@@ -1,9 +1,9 @@
 {
-    "severity": "Error",
+    "severity": "Critical",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: review platform webhook configurations",
-    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, review the documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-admission-plug-ins#.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-admission-plug-ins"],
+    "description": "Your cluster requires you to take action because the following custom ${WEBHOOK_TYPE} webhook(s) that you have installed are negatively impacting successful API requests on your cluster: ${WEBHOOK_NAMES}. Please review the webhooks installed and verify they are running correctly or remove them. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. For more information, review the documentation: https://docs.openshift.com/rosa/architecture/admission-plug-ins.html.",
+    "doc_references": ["https://docs.openshift.com/rosa/architecture/admission-plug-ins.html"],
     "internal_only": false
 }

--- a/osd/workernode_overloaded.json
+++ b/osd/workernode_overloaded.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "capacity-management",
   "summary": "Action required: Cluster health impacted by missing resource limits",

--- a/osd/workernode_overloaded_pid_limit_rosa.json
+++ b/osd/workernode_overloaded_pid_limit_rosa.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Cluster health impacted by High Pod PID Limits",

--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Error",
+  "severity": "Major",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Fix workload deployed in a restricted project",


### PR DESCRIPTION
Resolves OSD-22152

This PR is a first pass at updating all of our service log severities to be in line with what is [documented by OCM](https://gitlab.cee.redhat.com/service/ocm-service-log#severity-levels).

This PR was a quick attempt to label each template appropriately to unblock XCMSTRAT-258 and may require further grooming in the future.

To summarize the OCM documentation linked above, here is the rough decision tree I used to adjust severities:

1. Are we asking the customer to perform some action?
    1. Yes -> Is there an impending service/cluster outage, or SLA impact if they don't perform the action?
        1. Yes -> Critical
        1. No -> Major
    1. No -> Is the customer's cluster function impacted?
        1. Yes -> Warning
        1. No -> Info