### PR TITLE
Add new 'invalid_registry_policy.json' template

### DIFF
--- a/osd/invalid_registry_policy.json
+++ b/osd/invalid_registry_policy.json
@@ -1,0 +1,9 @@
+{
+  "severity": "Error",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Action required: container registry policy invalid",
+  "description": "Your cluster requires you to take action because the image.config.openshift.io/cluster object on your cluster does not allow workloads to pull from a required container registry. Please update this object to allow nodes to pull from ${REGISTRY}. For more information, see https://docs.openshift.com/rosa/openshift_images/image-configuration.html#.",
+  "doc_references": ["https://docs.openshift.com/rosa/openshift_images/image-configuration.html"],
+  "internal_only": false
+}


### PR DESCRIPTION
Adds a new template to cover cases where the cluster's image registry policy is invalid.