### PR TITLE
ROSA notification for cases when non RH user accessess ETCD

### DIFF
--- a/rosa/PlatformComponentNonRedHat.json
+++ b/rosa/PlatformComponentNonRedHat.json
@@ -1,0 +1,15 @@
+{
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Platform component accessed by non-Red Hat SRE user",
+  "description": "A user on your system, ${USER}, has accessed or modified a platform component, ${COMPONENT}, which is the responsibility of Red Hat SRE. Tampering with platform components can endanger SLAs. Please refer to https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html.",
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"
+  ],
+  "internal_only": false,
+  "_tags": [
+    "sop_SplunkNonRedHatAccessCoreSecrets",
+    "sop_SplunkNonSREAccessEtcdPods"
+  ]
+}


### PR DESCRIPTION
In [OHSS-33707](https://issues.redhat.com/browse/OHSS-33707), the [SplunkNonSREAccessEtcdPods](https://github.com/openshift/ops-sop/blob/master/v4/alerts/SplunkNonSREAccessEtcdPods.md) SOP was suggested. But the SOP does not point to a ROSA specific notification. A ROSA specific notification in this case important since the documentation and the Responsibility Matrix are not interchangeable between ROSA and OSD.

This PR adds a ROSA specific notification with the relevant documentation.