### PR TITLE
Add template for when customer-managed IngressController cannot run

### DIFF
--- a/osd/invalid_customer_ic.json
+++ b/osd/invalid_customer_ic.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
+    "summary": "Action Required: Invalid ingress configuration",
+    "description": "Your cluster's ingress ${INGRESS} cannot mount the volumes required for it to run. Please review the ingress configuration and create the necessary objects for it to run. For more information, see https://docs.openshift.com/rosa/networking/ingress-operator.html.",
+    "doc_references": ["https://docs.openshift.com/rosa/networking/ingress-operator.html"]
+}


### PR DESCRIPTION
Adds new template to cover instances of customer-managed ingresscontrollers lacking secrets/certs needed to run the router pods.