### PR TITLE
Add new notifications for stopping infra nodes

### DIFF
--- a/osd/customer_stopped_infra_node.json
+++ b/osd/customer_stopped_infra_node.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Critical",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
+    "summary": "Action required: Restart control plane node",
+    "description": "Your cluster requires you to take action. Red Hat SRE have observed that a user has stopped one or more of your cluster's infra instances: `${INSTANCE}`. Please note that stopping instances is not supported and may impact your cluster's SLA and ability to upgrade. Refer to the Responsibility Assignment guide for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#.",
+    "internal_only": false
+}

--- a/osd/customer_stopped_infra_node_rosa.json
+++ b/osd/customer_stopped_infra_node_rosa.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Critical",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
+    "summary": "Action required: Restart control plane node",
+    "description": "Your cluster requires you to take action. Red Hat SRE have observed that a user has stopped one or more of your cluster's infra instances: `${INSTANCE}`. Please note that stopping instances is not supported and may impact your cluster's SLA and ability to upgrade. Refer to the Responsibility Assignment guide for more information: https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#.",
+    "internal_only": false
+}


### PR DESCRIPTION
Service log template for when a customer stops or terminates their infra node instances in AWS.