### PR TITLE
OSDOCS-9654: Update doc references for managed resources

### DIFF
--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -3,8 +3,10 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-security",
   "summary": "Non-Red Hat Access Core Secrets",
-  "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html#.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
+  "description": "A Non-Red Hat user accessed core system secrets, ${SECRET_NAME}. This event can have an impact on SLAs. In some cases, Red Hat will proactively rotate secrets critical to OpenShift functionality. Please refer to https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/support/troubleshooting#sd-managed-resources-overview_sd-managed-resources.",
+  "doc_references": [
+    "https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/support/troubleshooting#sd-managed-resources-overview_sd-managed-resources"
+  ],
   "internal_only": false,
   "_tags": [
     "sop_SplunkNonRedHatAccessCoreSecrets"

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -3,8 +3,10 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Non-System Change SRE API Endpoint",
-  "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.openshift.com/dedicated/osd_architecture/osd_policy/policy-responsibility-matrix.html#.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-policy-responsibility-matrix"],
+  "description": "A Non-system user changed an SRE API endpoint, ${ENDPOINT}. This event can have an impact on SLAs. Red Hat will proactively repair API endpoint changes that were made. Please refer to https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/support/troubleshooting#sd-managed-resources-overview_sd-managed-resources.",
+  "doc_references": [
+    "https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/support/troubleshooting#sd-managed-resources-overview_sd-managed-resources"
+  ],
   "internal_only": false,
   "_tags": [
     "t_network",


### PR DESCRIPTION
As requested by [OSDOCS-9654](https://issues.redhat.com//browse/OSDOCS-9654), I updated the doc references for two service logs to point to the list of Red Hat managed resources.