### PR TITLE
New SL for ingress controllers which can now directly be defined by customers

### DIFF
--- a/osd/ingress_controller_cert_missconfiguration.json
+++ b/osd/ingress_controller_cert_missconfiguration.json
@@ -1,0 +1,10 @@
+{
+  "severity": "Critical",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
+  "_tags": ["t_network", "t_config"],
+  "summary": "Action required: update ingress controller configuration",
+  "description": "The application domain '${DOMAIN}' has a malformed or misconfigured certificate. Please review the certificate provided by the '${CONFIGMAP}' configmap in the '${CM_NS}' namespace to restore functionality to your cluster. For additional information, refer to the following documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-ingress-controller-configuration-parameters_configuring-ingress.",
+  "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-ingress-controller-configuration-parameters_configuring-ingress"],
+  "internal_only": false
+}


### PR DESCRIPTION
SL is derived from this one:
https://github.com/openshift/managed-notifications/blob/fa43859b18109833b61e2c84abddc098f355442f/osd/custom_domain_cert_misconfiguration.json#L7