### PR TITLE
OSD-20856 - Remove deprecated servicelog template

### DIFF
--- a/osd/ClusterOperatorIngressDegradedServiceMesh.json
+++ b/osd/ClusterOperatorIngressDegradedServiceMesh.json
@@ -1,9 +1,0 @@
-{
-  "severity": "Critical",
-  "service_name": "SREManualAction",
-  "log_type": "cluster-networking",
-  "_tags": ["t_network"],
-  "summary": "Cluster ingress degraded",
-  "description": "The cluster ingress operator for your cluster is currently degraded due to Service Mesh. This may cause instability in the service and may impact the supportability of your cluster.",
-  "internal_only": false
-}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-20856


---


Removes a deprecated ServiceLog template, `ClusterOperatorIngressDegradedServiceMesh.json`