### PR TITLE
Add unable_to_create_machine_invalid_type.json template

### DIFF
--- a/osd/unable_to_create_machine_invalid_type.json
+++ b/osd/unable_to_create_machine_invalid_type.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Major",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
+    "summary": "Cluster machine creation blocked, action required",
+    "description": "Action Required: Your cluster is unable to create a machine with type '${INVALID_MACHINE_TYPE}' due to ${REASON}. Please ${REMEDIATION} in order to restore your cluster to full functionality. For more information on machines, refer to: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html.",
+    "internal_only": false,
+		"doc_references": ["https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html"]
+}


### PR DESCRIPTION
Adds a new template covering cases where clusters are unable to create a machine of a specific type.