### PR TITLE
Add SL for blocking API ingress

### DIFF
--- a/osd/NetworkMisconfiguration_ApiserverIngressBlocked.json
+++ b/osd/NetworkMisconfiguration_ApiserverIngressBlocked.json
@@ -1,0 +1,10 @@
+{
+    "severity": "Critical",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-networking",
+    "_tags": ["t_network"],
+    "summary": "Action required: API server ingress misconfiguration",
+    "description": "Your cluster requires you to take action. The ingress to the API server is misconfigured, resulting in SRE not being able to access the cluster. Without action, your cluster's SLA may be impacted. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/dedicated/security/rh-required-whitelisted-IP-addresses-for-sre-access.html",
+    "doc_references": ["https://docs.openshift.com/dedicated/security/rh-required-whitelisted-IP-addresses-for-sre-access.html"],
+    "internal_only": false
+  }

--- a/osd/NetworkMisconfiguration_ApiserverIngressBlocked.json
+++ b/osd/NetworkMisconfiguration_ApiserverIngressBlocked.json
@@ -4,7 +4,7 @@
     "log_type": "cluster-networking",
     "_tags": ["t_network"],
     "summary": "Action required: API server ingress misconfiguration",
-    "description": "Your cluster requires you to take action. The ingress to the API server is misconfigured, resulting in SRE not being able to access the cluster. Without action, your cluster's SLA may be impacted. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/dedicated/security/rh-required-whitelisted-IP-addresses-for-sre-access.html",
+    "description": "Your cluster requires you to take action. The ingress to the API server is misconfigured, resulting in SRE not being able to access the cluster. Without action, your cluster's SLA may be impacted. Please refer to the documentation regarding allowlist requirements: https://docs.openshift.com/dedicated/security/rh-required-whitelisted-IP-addresses-for-sre-access.html.",
     "doc_references": ["https://docs.openshift.com/dedicated/security/rh-required-whitelisted-IP-addresses-for-sre-access.html"],
     "internal_only": false
   }


### PR DESCRIPTION
In some cases, customer may block the ingress IP for external facing API server, resulting in SRE not being able access the cluster.  This SL asks the customer to follow the doc to allow the required IPs.