### PR TITLE
OSD-24259: osdctl network verify should prompt putting clusters into LS if DMS/PD is blocked 

### DIFF
--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,6 +1,6 @@
 {
   "kind": "LimitedSupportReason",
-  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
+  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
   "detection_type": "manual",
   "summary": "Cluster is in Limited Support due to unsupported network configuration"
 }

--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,0 +1,6 @@
+{
+  "kind":"LimitedSupportReason",
+  "details":"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
+  "detection_type":"manual",
+  "summary":"Cluster is in Limited Support due to unsupported network configuration"
+}

--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,6 +1,6 @@
 {
   "kind": "LimitedSupportReason",
-  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URL}. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
+  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URLS}. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
   "detection_type": "manual",
   "summary": "Cluster is in Limited Support due to unsupported network configuration"
 }

--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,6 +1,6 @@
 {
   "kind": "LimitedSupportReason",
-  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
+  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: ${URL}. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
   "detection_type": "manual",
   "summary": "Cluster is in Limited Support due to unsupported network configuration"
 }

--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,6 +1,6 @@
 {
-  "kind":"LimitedSupportReason",
-  "details":"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
-  "detection_type":"manual",
-  "summary":"Cluster is in Limited Support due to unsupported network configuration"
+  "kind": "LimitedSupportReason",
+  "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs",
+  "detection_type": "manual",
+  "summary": "Cluster is in Limited Support due to unsupported network configuration"
 }


### PR DESCRIPTION
**JIRA**: [OSD-24259](https://issues.redhat.com//browse/OSD-24259)

Summary:
This is a Child PR of [#609](https://github.com/openshift/osdctl/pull/609). This template will be passed, when we put cluster into LS when the PD/DMS is unreachable