### PR TITLE
Update ingress_controller_cert_missconfiguration.json

### DIFF
--- a/osd/ingress_controller_cert_missconfiguration.json
+++ b/osd/ingress_controller_cert_missconfiguration.json
@@ -4,7 +4,7 @@
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],
   "summary": "Action required: update ingress controller configuration",
-  "description": "The application domain '${DOMAIN}' has a malformed or misconfigured certificate. Please review the certificate provided by the '${CONFIGMAP}' configmap in the '${CM_NS}' namespace to restore functionality to your cluster. For additional information, refer to the following documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-ingress-controller-configuration-parameters_configuring-ingress.",
-  "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-ingress-controller-configuration-parameters_configuring-ingress"],
+  "description": "The application domain '${DOMAIN}' has a missing or misconfigured certificate. Please review the configuration of the '${INGRESS_CONTROLLER}' IngressController in the 'openshift-ingress-operator' namespace and ensure the specified certificate is present and valid in order to restore functionality to your cluster. For additional information, refer to the following documentation: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-ingress-setting-a-custom-default-certificate_configuring-ingress.",
+  "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/networking/configuring-ingress#nw-create-custom-ingress-controller_configuring-ingress"],
   "internal_only": false
 }


### PR DESCRIPTION
Modified SL wording to more accurately match docs, which don't refer to ConfigMaps but instead instruct the customer to edit the IC directly