### PR TITLE
Create NetworkMigrationBlocked.json

### DIFF
--- a/osd/NetworkMigrationBlocked.json
+++ b/osd/NetworkMigrationBlocked.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Major",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-networking",
+    "summary": "Action Required: Network Plugin Migration Blocked",
+    "description": "Your cluster is unable to initiate its live network plugin migration because the following pod(s) have an unsupported egress router pod annotation: ${PODS}. Please delete these pods or remove their `pod.network.openshift.io/assign-macvlan` annotations. Refer to the following documentation for further details: https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#removing-egress-router-pods-before-initiating-limited-live-migration_migrate-from-openshift-sdn.",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR creates a service log template corresponding the new NetworkMigrationBlocked alert added by [OSD-25335](https://issues.redhat.com/browse/OSD-25335). This service log will be linked to by the SOP added in openshift/ops-sop#3346

Note: this SL links to OCP docs because there are no comparable OSD/ROSA-specific docs on live migration yet. Once live migration GAs in 2025Q1, we should check if new docs have been added