### PR TITLE
Add servicelog for SDN to OVN investigation

### DIFF
--- a/osd/general_investigation.json
+++ b/osd/general_investigation.json
@@ -1,8 +1,0 @@
-{
-  "severity": "Warning",
-  "service_name": "SREManualAction",
-  "summary": "Potential cluster issue identified",
-  "description": "We have identified a potential issue with your cluster that is currently being investigated by SRE.  No further action is required at this time.",
-  "internal_only": false,
-  "_tags": []
-}

--- a/osd/general_investigation.json
+++ b/osd/general_investigation.json
@@ -1,7 +1,8 @@
 {
   "severity": "Warning",
   "service_name": "SREManualAction",
-  "summary": "Potential issue investigation",
+  "summary": "Potential cluster issue identified",
   "description": "We have identified a potential issue with your cluster that is currently being investigated by SRE.  No further action is required at this time.",
-  "internal_only": false
+  "internal_only": false,
+  "_tags": []
 }

--- a/osd/general_investigation.json
+++ b/osd/general_investigation.json
@@ -1,0 +1,7 @@
+{
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Potential issue investigation",
+  "description": "We have identified a potential issue with your cluster that is currently being investigated by SRE.  No further action is required at this time.",
+  "internal_only": false
+}

--- a/osd/sdn_to_ovn_migration_investigation.json
+++ b/osd/sdn_to_ovn_migration_investigation.json
@@ -2,7 +2,7 @@
     "severity": "Major",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
-    "summary": "SRE investigation SDN to OVN migration",
+    "summary": "SRE is investigating delays in SDN to OVN migration",
     "description": "Your cluster's SDN to OVN migration is taking longer than expected. SRE is actively investigating this issue, please see the referenced documenation for more information.",
     "doc_references": ["https://access.redhat.com/articles/7104155"],
     "internal_only": false

--- a/osd/sdn_to_ovn_migration_investigation.json
+++ b/osd/sdn_to_ovn_migration_investigation.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "SRE is investigating delays in SDN to OVN migration",
-    "description": "Your cluster's SDN to OVN migration is taking longer than expected. SRE is actively investigating this issue, please see the referenced documenation for more information.",
+    "description": "Your cluster's SDN to OVN migration is taking longer than expected. SRE is actively investigating this issue. Please see the referenced documentation for further information.",
     "doc_references": ["https://access.redhat.com/articles/7104155"],
     "internal_only": false
   }

--- a/osd/sdn_to_ovn_migration_investigation.json
+++ b/osd/sdn_to_ovn_migration_investigation.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Major",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
+    "summary": "SRE investigation SDN to OVN migration",
+    "description": "Your cluster's SDN to OVN migration is taking longer than expected. SRE is actively investigating this issue, please see the referenced documenation for more information.",
+    "doc_references": ["https://access.redhat.com/articles/7104155"],
+    "internal_only": false
+  }


### PR DESCRIPTION
A generic servicelog to inform customer's that SRE is looking into potential issues with their SDN to OVN migration