### PR TITLE
Feat: add tag policy SL

### DIFF
--- a/osd/aws/TagPolicyBlocksInstanceCreation.json
+++ b/osd/aws/TagPolicyBlocksInstanceCreation.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Major",
+    "service_name": "SREManualAction",
+    "summary": "Cluster degraded, action required",
+    "description": "Your cluster requires action because the machine-api operator is unable to provision new instances. Red Hat has determined that an AWS Tag Policy is causing the issue. Please remove the tag policy that enforces the 'ProductOwnerEmail' tag key to restore full functionality.",
+    "internal_only": false
+}


### PR DESCRIPTION
This PR adds a new SL to send for customers that add tag policies which block instance creations: (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html)

MAPI error:
```

 - lastTransitionTime: "2025-03-17T10:44:59Z"
      message: 'error launching instance: The resource is missing the tag key(s) ''ExampleTag''
        specified by the tag policy.'
      reason: MachineCreationFailed
      status: "False"
      type: MachineCreation
```