### PR TITLE
Replace ROSA doc refs for OSD cluster_cannot_be_recovered notification.

### DIFF
--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -3,8 +3,8 @@
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Cluster destroyed, cannot be recovered",
-  "description": "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster#.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_classic_clusters/rosa-sts-deleting-cluster","https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/installing_accessing_and_deleting_openshift_dedicated_clusters/osd-deleting-a-cluster"],
+  "description": "SRE have noticed that your cluster was deleted from the IaaS infrastructure. The cluster cannot be restored, therefore SRE will take actions to completely remove the cluster. In the future when you need to delete a cluster, please follow the documentation guidelines for deleting a cluster: https://docs.openshift.com/dedicated/osd_quickstart/osd-quickstart.html#deleting-cluster_osd-getting-started .",
+  "doc_references": ["https://docs.openshift.com/dedicated/osd_quickstart/osd-quickstart.html#deleting-cluster_osd-getting-started"],
   "internal_only": false,
   "_tags": [
     "sop_cluster_has_gone_missing"


### PR DESCRIPTION
Both osd and rosa SL notifications are referencing ROSA docs for deleting an OSD cluster. 

This is replacing the current ROSA doc references with the previous osd doc reference:

https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/getting_started/osd-getting-started#deleting-cluster_osd-getting-started
