### PR TITLE
Updating the SL to match the latest OCM feature of self-service ownership transfers

### DIFF
--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",
-    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please follow the documentation https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets to arrange a new cluster owner.",
+    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please follow the documentation to arrange a new cluster owner https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets",
     "internal_only": false,
     "doc_references": ["https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets"]
 }

--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -3,6 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",
-    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please raise a support case with Red Hat to nominate a new owner for the cluster in https://console.redhat.com/openshift/.",
-    "internal_only": false
+    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please follow the documentation https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets to arrange a new cluster owner.",
+    "internal_only": false,
+    "doc_references": ["https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets"]
 }

--- a/ocm/cluster_owner_disabled.json
+++ b/ocm/cluster_owner_disabled.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-ownership",
     "summary": "Action required: Arrange new cluster owner",
-    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please follow the documentation to arrange a new cluster owner https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets",
+    "description": "Your cluster requires you to take action because it is no longer owned by a user with an enabled Red Hat account. This will impact the cluster's ability to upgrade to future versions. Please follow the documentation to arrange a new cluster owner https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets.",
     "internal_only": false,
     "doc_references": ["https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets"]
 }


### PR DESCRIPTION
As per the email announcement with subject _[Announcement] Self-service capability to transfer ownership of ROSA Classic clusters through OCM_. OCM has the feature to self-service the ownership transfer. Updating the SL