### PR TITLE
Update custom ingress controlelr SL

### DIFF
--- a/osd/custom_ingress_controller_misconfiguration.json
+++ b/osd/custom_ingress_controller_misconfiguration.json
@@ -3,7 +3,7 @@
   "service_name": "SREManualAction",
   "log_type":"cluster-networking",
   "summary": "Action required: update cluster configuration",
-  "description": "Red Hat SRE have noticed custom ingress controllers ${NAME} installed in the 'openshift-ingress' namespace is misconfigured and causing interruptions in regular cluster operations. Please review the non-default IngressController configuration. For more information, please refer to:https://docs.openshift.com/rosa/networking/networking_operators/ingress-operator.html#nw-create-custom-ingress-controller_configuring-ingress.",
+  "description": "Red Hat SRE have noticed custom ingress controllers ${NAME} installed in the 'openshift-ingress-operator' namespace is misconfigured and causing interruptions in regular cluster operations. Please review the non-default IngressController configuration. For more information, please refer to:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/networking/networking-operators#nw-create-custom-ingress-controller_configuring-ingress.",
   "doc_references": ["https://access.redhat.com/solutions/6970094"],
   "internal_only": false,
   "_tags": [


### PR DESCRIPTION
This PR:
- Update the namespace to `openshift-ingress-operator` as `IngressController` should be created in this namespace.
- Update the link from the legacy docs.openshift.com to docs.redhat.com.
