### PR TITLE
Add internal service log for resize of request serving nodes

### DIFF
--- a/hcp/RequestServingNode_resized.json
+++ b/hcp/RequestServingNode_resized.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-scaling",
+  "summary": "Request Serving Node Resize",
+  "description": "SRE has resized request serving nodes to ${INSTANCE_TYPE} to accommodate cluster load.",
+  "internal_only": true
+}


### PR DESCRIPTION
HCP [apiErrorBudgetBurn ](https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/api-ErrorBudgetBurn.md#api-errorbudgetburn) currently require SRE to resize serving nodes as soon as the api-ErrorBudgetBurn alert is triggered for HCP Clusters to prevent disruptions. The internal service log will help track how often serving nodes are being resized.