### PR TITLE
style: fix markdownlint violations in all markdown files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working
+with code in this repository.
 
 ## Essential Commands
 
 **Validation:**
+
 ```bash
 # Validate all notification descriptions end with a period
 make validate
@@ -17,6 +19,7 @@ make checkseverity
 ```
 
 **MCP Server (semantic search over notifications):**
+
 ```bash
 # Build MCP server container
 make build-container
@@ -26,7 +29,8 @@ make build-container
 
 ## Repository Architecture
 
-This repository contains OpenShift Managed Services notification templates organized by service type:
+This repository contains OpenShift Managed Services notification templates
+organized by service type:
 
 - **osd/** - OpenShift Dedicated notifications (150+ templates)
   - **osd/aws/** - AWS-specific OSD notifications
@@ -34,7 +38,8 @@ This repository contains OpenShift Managed Services notification templates organ
 - **hcp/** - Hosted Control Plane notifications
 - **cluster/** - General cluster notifications
 - **ocm/** - OpenShift Cluster Manager notifications
-- **mcp/** - MCP server for semantic search over notification templates (separate subproject with own CLAUDE.md)
+- **mcp/** - MCP server for semantic search over notification templates
+  (separate subproject with own CLAUDE.md)
 - **scripts/** - Validation scripts
 
 ### Notification Template Structure
@@ -54,43 +59,58 @@ Each notification is a JSON file with required fields:
 ```
 
 **Key constraints:**
+
 - `description` field MUST end with a period (enforced by `make validate`)
-- `severity` must be one of: Debug, Info, Warning, Major, Critical (enforced by `scripts/checkseverity.sh`)
-- Templates may contain variable placeholders like `${TIME}`, `${CLUSTER_ID}`, `${NAMESPACE}`
+- `severity` must be one of: Debug, Info, Warning, Major, Critical
+  (enforced by `scripts/checkseverity.sh`)
+- Templates may contain variable placeholders like `${TIME}`, `${CLUSTER_ID}`,
+  `${NAMESPACE}`
 
 ### Posting Notifications
 
-Notifications are posted via the [OpenShift Service Logs API](https://api.openshift.com/?urls.primaryName=Service%20logs#/default/post_api_service_logs_v1_cluster_logs) using `osdctl`:
+Notifications are posted via the
+[OpenShift Service Logs API](https://api.openshift.com/?urls.primaryName=Service%20logs#/default/post_api_service_logs_v1_cluster_logs)
+using `osdctl`:
 
 ```bash
 osdctl servicelog post <cluster-uuid> -t <template-url>
 ```
 
 Example:
+
 ```bash
 osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
-  -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
+  -t https://raw.githubusercontent.com/openshift/managed-notifications/\
+master/osd/aws/InstallFailed_TooManyBuckets.json
 ```
 
 ### Tag System
 
-Some templates include a `_tag` field for categorization (e.g., `t_network` for network-related issues). Search GitHub with these tags to find related templates.
+Some templates include a `_tag` field for categorization (e.g., `t_network`
+for network-related issues). Search GitHub with these tags to find related
+templates.
 
 ## MCP Server Subproject
 
-The `mcp/` directory contains a standalone MCP (Model Context Protocol) server that provides semantic search over these notification templates using vector embeddings. This subproject:
+The `mcp/` directory contains a standalone MCP (Model Context Protocol) server
+that provides semantic search over these notification templates using vector
+embeddings. This subproject:
 
-- Has its own `mcp/CLAUDE.md` with detailed architecture and development instructions
+- Has its own `mcp/CLAUDE.md` with detailed architecture and development
+  instructions
 - Uses Python + uv for dependency management
 - Builds ChromaDB vector database from notification templates
 - Exposes MCP tools for AI-powered notification search
 
-When working on the MCP server, refer to `mcp/CLAUDE.md` for specific guidance.
+When working on the MCP server, refer to `mcp/CLAUDE.md` for specific
+guidance.
 
 ## Validation Scripts
 
-**scripts/checklinks.sh** - Validates all HTTP/HTTPS URLs in templates return 200 (not 404)
+**scripts/checklinks.sh** - Validates all HTTP/HTTPS URLs in templates return
+200 (not 404)
 
-**scripts/checkseverity.sh** - Ensures all templates have valid severity values
+**scripts/checkseverity.sh** - Ensures all templates have valid severity
+values
 
 These run in CI and should pass before merging changes.

--- a/README.md
+++ b/README.md
@@ -7,38 +7,48 @@ Notification templates for OpenShift Managed services
 Select the corresponding message and send it as a `POST` to
 [api.openshift.com servicelog](https://api.openshift.com/?urls.primaryName=Service%20logs#/default/post_api_service_logs_v1_cluster_logs).
 
-> :warning: Please review each template before post to make sure all the parameters are passed with -p 
-
-> :books: If you are not sure which servicelog to send, you can use the generic one [here](./osd/unknown_failure.json)
+> :warning: Please review each template before post to make sure all the
+> parameters are passed with -p
+>
+> :books: If you are not sure which servicelog to send, you can use the
+> generic one in [osd/unknown_failure.json](./osd/unknown_failure.json)
 
 ### Examples
 
 Using [osdctl](https://github.com/openshift/osdctl)
 
-1. Authenticate at https://cloud.redhat.com/openshift/token
+1. Authenticate at <https://cloud.redhat.com/openshift/token>
 2. Post servicelog
 
-    ```
-    osdctl servicelog post <cluster UUID> -t <notificationTemplateUrl> 
-    ```
+```bash
+osdctl servicelog post <cluster UUID> -t <notificationTemplateUrl>
+```
 
-    Example:
+Example:
 
-    ```
-    osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
-    ```
+```bash
+osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
+  -t https://raw.githubusercontent.com/openshift/managed-notifications/\
+master/osd/aws/InstallFailed_TooManyBuckets.json
+```
 
-Note: `Osdctl` supports the usage of the unique cluster name, or the internal- and external ID as clusterID.
+Note: `Osdctl` supports the usage of the unique cluster name, or the
+internal- and external ID as clusterID.
 
 ### Tags
+
 Some template files have a `_tag` field for easier searching.
 
-For example, in GitHub, searching `t_network` will show you all the network related template files.
+For example, in GitHub, searching `t_network` will show you all the network
+related template files.
 
 ## MCP Search Server
 
-This repository includes an MCP (Model Context Protocol) server that provides semantic search capabilities over the notification templates. See [mcp/README.md](mcp/README.md) for setup and usage instructions.
+This repository includes an MCP (Model Context Protocol) server that provides
+semantic search capabilities over the notification templates. See
+[mcp/README.md](mcp/README.md) for setup and usage instructions.
 
 ## Validating Managed Notifications
 
-Run `make validate` to perform basic validations against the notifications configured in this repo.
+Run `make validate` to perform basic validations against the notifications
+configured in this repo.

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -1,10 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
 
 ## Essential Commands
 
 **Development:**
+
 ```bash
 # Install dependencies
 uv sync
@@ -30,44 +32,64 @@ podman run -p 8000:8000 managed-notifications-search
 
 ## Architecture Overview
 
-This is an MCP (Model Context Protocol) server that provides semantic search over OpenShift service notification logs using vector embeddings. The system has two main phases:
+This is an MCP (Model Context Protocol) server that provides semantic search
+over OpenShift service notification logs using vector embeddings. The system
+has two main phases:
 
 ### Build Phase (Offline)
-- **Input**: JSON notification files from `managed-notifications/` directory
-- **Processing**: `scripts/build_embeddings.py` extracts searchable text, creates embeddings via sentence-transformers, stores in ChromaDB
-- **Output**: Persistent vector database in `chroma_db/` directory
-- **Key Feature**: Extracts variable placeholders (e.g., `${TIME}`, `${POD}`) from notification templates
 
-### Runtime Phase (Online) 
+- **Input**: JSON notification files from `managed-notifications/` directory
+- **Processing**: `scripts/build_embeddings.py` extracts searchable text,
+  creates embeddings via sentence-transformers, stores in ChromaDB
+- **Output**: Persistent vector database in `chroma_db/` directory
+- **Key Feature**: Extracts variable placeholders (e.g., `${TIME}`, `${POD}`)
+  from notification templates
+
+### Runtime Phase (Online)
+
 - **Server**: `main.py` implements FastMCP server with HTTP transport
-- **Search**: Uses same embedding model to vectorize queries, performs similarity search in ChromaDB
+- **Search**: Uses same embedding model to vectorize queries, performs
+  similarity search in ChromaDB
 - **Tools**: Exposes `search_service_logs` and `get_database_stats` MCP tools
 
 ### Data Flow
-1. Problem statement → Query embedding → Vector similarity search → Ranked results
-2. Results include notification JSON, metadata (folder, severity, variables), and similarity scores
+
+1. Problem statement → Query embedding → Vector similarity search →
+   Ranked results
+2. Results include notification JSON, metadata (folder, severity, variables),
+   and similarity scores
 
 ## Critical Implementation Details
 
-**Variable Handling**: Service notifications contain template variables like `${NAMESPACE}`, `${REASON}` that must be interpolated. The system:
+**Variable Handling**: Service notifications contain template variables like
+`${NAMESPACE}`, `${REASON}` that must be interpolated. The system:
+
 - Extracts variables using regex during embedding creation
 - Stores them as JSON strings in ChromaDB metadata (scalar value requirement)
 - Returns parsed variable lists to guide LLM interpolation workflow
 
-**Container Architecture**: Multi-stage build separates embedding creation (expensive, cached) from runtime (lightweight). Only rebuilds embeddings when notification files or embedding script change.
+**Container Architecture**: Multi-stage build separates embedding creation
+(expensive, cached) from runtime (lightweight). Only rebuilds embeddings when
+notification files or embedding script change.
 
 **Project Scripts**: Uses uv project scripts defined in `pyproject.toml`:
-- `serve = "main:main"` 
+
+- `serve = "main:main"`
 - `build-embeddings = "scripts.build_embeddings:main"`
 
-**MCP Configuration**: `mcp-config.json` provides ready-to-use HTTP transport config for MCP clients connecting to `localhost:8000/mcp`.
+**MCP Configuration**: `mcp-config.json` provides ready-to-use HTTP transport
+config for MCP clients connecting to `localhost:8000/mcp`.
 
 ## Environment Variables
 
-- `EMBEDDING_MODEL`: Override default sentence transformer model (default: "all-MiniLM-L6-v2")
+- `EMBEDDING_MODEL`: Override default sentence transformer model
+  (default: "all-MiniLM-L6-v2")
 - `HOST`: Server bind address (default: "127.0.0.1", container uses "0.0.0.0")
 - `PORT`: Server port (default: "8000")
 
 ## Database Dependencies
 
-The MCP server requires the ChromaDB database to exist before startup. Always run `uv run build-embeddings` before `uv run serve` in fresh environments. The embeddings script includes a test search for "missing or insufficient permissions" to validate the database.
+The MCP server requires the ChromaDB database to exist before startup. Always
+run `uv run build-embeddings` before `uv run serve` in fresh environments. The
+embeddings script includes a test search for "missing or insufficient
+permissions" to validate the database.


### PR DESCRIPTION
Fix line length, blank line, and code block formatting issues to comply with markdownlint rules across CLAUDE.md, mcp/CLAUDE.md, and README.md.
