### PR TITLE
Exclude mcp/ from severity checking

### DIFF
--- a/scripts/checkseverity.sh
+++ b/scripts/checkseverity.sh
@@ -13,6 +13,6 @@ do
     echo "file $file has invalid 'severity' value! must be one of 'Debug', 'Info', 'Warning', 'Major', 'Critical'"
     exit 1
   fi
-done < <(find . -type f -name "*.json" -print0)
+done < <(find . -type f -name "*.json" -not -path "./mcp/*" -print0)
 
 echo "pass!"


### PR DESCRIPTION
Ensure the checkseverity script doesn't fail for json files in the mcp dir.