### PR TITLE
adds limited support reason for blocked installer IAM role

### DIFF
--- a/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
+++ b/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
@@ -2,7 +2,7 @@
     "kind": "LimitedSupportReason",
     "severity": "Warning",
     "summary": "Cluster is in Limited Support due to Blocked Installer Role IAM Access",
-    "details": "Access to the Installer Role is currently being blocked. This can lead to failing important cluster management functions including but not limited to certificate renewals, which will cause loss of access to the cluster. Please remediate this issue in order to restore support",
+    "details": "Access to the Installer Role: ${ROLE_NAME} is currently being blocked. This can lead to failing important cluster management functions including but not limited to certificate renewals, which will cause loss of access to the cluster. Please remediate this issue in order to restore support",
     "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],
     "detection_type": "manual"
 }

--- a/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
+++ b/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
@@ -1,0 +1,8 @@
+{
+    "kind": "LimitedSupportReason",
+    "severity": "Warning",
+    "summary": "Cluster is in Limited Support due to Blocked Installer Role IAM Access",
+    "details": "Access to the Installer Role is currently being blocked. This can lead to failing important cluster management functions including but not limited to certificate renewals, which will cause loss of access to the cluster. Please remediate this issue in order to restore support",
+    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],
+    "detection_type": "manual"
+}


### PR DESCRIPTION
When customers block this role and we cannot renew certificates, this WILL cause an API server outage if that certificate expires. We should therefore put these clusters into limited support.