### PR TITLE
Add new servicelog template for customer webhooks blocking nodepool upgrade

### DIFF
--- a/hcp/webhook_blocking_nodepool_update.json
+++ b/hcp/webhook_blocking_nodepool_update.json
@@ -1,0 +1,12 @@
+{
+  "severity": "Major",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Action required: Webhook blocking pod eviction during nodepool update",
+  "description": "Your cluster's nodepool `${NODEPOOL}` is unable to complete an update because a validating or mutating webhook `${WEBHOOK_NAME}` is preventing the eviction of pod `${POD}` in namespace `${NAMESPACE}`. Please review the webhook configuration and update it to allow pod evictions during node updates. Without action, your nodepool update may remain blocked. For more information on admission webhooks, see the documentation: https://docs.openshift.com/rosa/architecture/admission-plug-ins.html.",
+  "doc_references": [
+    "https://docs.openshift.com/rosa/architecture/admission-plug-ins.html",
+    "https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/"
+  ],
+  "internal_only": false
+}


### PR DESCRIPTION
Customer webhooks can impact an HCP cluster's ability to upgrade nodepools in a timely matter, which can cause `HCPNodepoolUpgradeDelay` alerts. This adds a template asking the customer to review their webhook configuration in this context