### PR TITLE
[OHSS-49752] Handle 4.16 Stable channel EOL for ROSA HCP. Two managed notifications

### DIFF
--- a/hcp/eus_transition_attempted.json
+++ b/hcp/eus_transition_attempted.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-upgrades",
+  "summary": "Attempted transition to EUS channel - Resolution in progress",
+  "description": "An attempt was made to transition your cluster from the Stable update channel to the Extended Update Support (EUS) channel to maintain continued support. During this process, your cluster's recurring upgrade policy was temporarily removed and then restored to its original settings. However, technical issues were encountered during the channel transition. Our team is currently working on a resolution to complete the EUS transition. Your cluster's upgrade policy configuration has been preserved at its original settings, and no further action is required from you at this time. For more information about EUS, see: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-minor-versions_rosa-hcp-life-cycle.",
+  "internal_only": false
+}

--- a/hcp/eus_transition_success.json
+++ b/hcp/eus_transition_success.json
@@ -1,0 +1,8 @@
+{
+  "severity": "Info",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-upgrades",
+  "summary": "Cluster transitioned to EUS channel to extend support lifecycle",
+  "description": "Your cluster has been transitioned from the stable update channel to the Extended Update Support (EUS) channel to extend its support lifecycle. This provides additional time for planning your upgrade to a newer OpenShift version. For more information about EUS, see: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#rosa-minor-versions_rosa-hcp-life-cycle.",
+  "internal_only": false
+}


### PR DESCRIPTION
As part of [OHSS-49752] Handle 4.16 Stable channel EOL for ROSA HCP, we want to automate the entire workflow, including all scenarios learned during manual execution. This PR adds two SL:
1. When the transition is successful, we need to notify the customer 
2. When the transition failed, but the Upgrade policy was changed, which triggered a separate notification, and we need to notify the customer that we attempted but failed (approved by BU)