### PR TITLE
Add SL for orphaned resources

### DIFF
--- a/osd/orphaned_resource_blocking_operations.json
+++ b/osd/orphaned_resource_blocking_operations.json
@@ -1,0 +1,8 @@
+{
+    "severity": "Critical",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-lifecycle",
+    "summary": "Action required: Orphaned resource blocking ${OPERATION}",
+    "description": "Your cluster has an orphaned resource that is blocking ${OPERATION}. SRE has identified ${RESOURCE_TYPE} '${RESOURCE_NAME}' in namespace '${NAMESPACE}' as orphaned and preventing normal cluster functions. Please delete the resource. If you have questions about this operation, please open a support case.",
+    "internal_only": false
+}


### PR DESCRIPTION
Add a SL template about orphan resources. Sometime, there could be orphan resources that blocks operations. For example, I have seen a case, which an orphan pod blocking a service to delete, but somehow the namespace got forced deleted, leaving the pod not able to reconcile and failing the OVN database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added critical alerts for orphaned resource blocking operations, providing contextual details about affected operations, resource types, and namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->