### PR TITLE
Add a new notification for AWS subnet address range full

### DIFF
--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -1,0 +1,9 @@
+{
+  "severity": "Major",
+  "service_name": "SREManualAction",
+  "log_type": "General Notification",
+  "_tags": ["t_network"],
+  "summary": "Action required: Subnet address range is full",
+  "description": "Your cluster requires you to take action because subnet: ${SUBNET} has eight or less available IP addresses, resulting in ELB provisioning faulures. Please recreate your cluster within larger subnets, or free enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
+  "internal_only": false
+}

--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -4,6 +4,6 @@
   "log_type": "General Notification",
   "_tags": ["t_network"],
   "summary": "Action required: Subnet address range is near full",
-  "description": "Your cluster requires you to take action because subnet: ${SUBNET} has eight or less available IP addresses, resulting in ELB provisioning failures. Please recreate your cluster within larger subnets, or free enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
+  "description": "Your cluster requires you to take action because subnet ${SUBNET} has eight or fewer available IP addresses, resulting in ELB provisioning failures. Please recreate your cluster within larger subnets, or free up enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
   "internal_only": false
 }

--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -4,6 +4,6 @@
   "log_type": "General Notification",
   "_tags": ["t_network"],
   "summary": "Action required: Subnet address range is near full",
-  "description": "Your cluster requires you to take action because subnet: ${SUBNET} has eight or less available IP addresses, resulting in ELB provisioning faulures. Please recreate your cluster within larger subnets, or free enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
+  "description": "Your cluster requires you to take action because subnet: ${SUBNET} has eight or less available IP addresses, resulting in ELB provisioning failures. Please recreate your cluster within larger subnets, or free enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
   "internal_only": false
 }

--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -4,6 +4,6 @@
   "log_type": "General Notification",
   "_tags": ["t_network"],
   "summary": "Action required: Subnet address range is near full",
-  "description": "Your cluster requires you to take action because subnet ${SUBNET} has eight or fewer available IP addresses, resulting in ELB provisioning failures. Please recreate your cluster within larger subnets, or free up enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
+  "description": "Your cluster requires you to take action because subnet ${SUBNET} has eight or fewer available IP addresses, resulting in ELB provisioning failures. Please recreate your cluster within larger subnets, or free up enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer.",
   "internal_only": false
 }

--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -3,7 +3,7 @@
   "service_name": "SREManualAction",
   "log_type": "General Notification",
   "_tags": ["t_network"],
-  "summary": "Action required: Subnet address range is full",
+  "summary": "Action required: Subnet address range is near full",
   "description": "Your cluster requires you to take action because subnet: ${SUBNET} has eight or less available IP addresses, resulting in ELB provisioning faulures. Please recreate your cluster within larger subnets, or free enough addresses in the subnet. Without action, your cluster's SLA may be impacted, along with your ability to upgrade. Please refer to this documentation for more information: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#subnets-load-balancer .",
   "internal_only": false
 }


### PR DESCRIPTION
I've received ClusterOperator down alerts that are due to the ingress operator being unable to provision the ELB for the cluster because there are fewer than 8 IP address available within a subnet the ELB is assigned too. I wanted to make a more specific notification for this, since quota exceeded doesn't quite fit, as the customer cannot request a quota increase here from AWS.