### PR TITLE
Add notification for custom componentRoute TLS cert expired

### DIFF
--- a/osd/auth_operator_cert_expired.json
+++ b/osd/auth_operator_cert_expired.json
@@ -1,0 +1,13 @@
+{
+  "severity": "Critical",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-networking",
+  "_tags": ["t_network", "t_config"],
+  "summary": "Action required: Authentication operator degraded due to expired TLS certificate",
+  "description": "The authentication cluster operator on your cluster is unavailable because the TLS certificate serving the OAuth route has expired. The certificate expired at ${EXPIRY_TIME}. This prevents users from authenticating to the cluster via the OpenShift OAuth server. Please renew or replace the TLS certificate for the OAuth server route to restore authentication functionality. If you are using a custom domain with a user-provided certificate, ensure your certificate is renewed and updated in the corresponding secret.",
+  "doc_references": [
+    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/building_applications/deployments#osd-config-custom-domains-applications",
+    "https://access.redhat.com/articles/5599621"
+  ],
+  "internal_only": false
+}


### PR DESCRIPTION
Adds a new SL template that covers cases where a customer is using custom componentRoutes for ingress and the provided certificate expires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added alert configuration for certificate expiration events to enable proactive monitoring and timely notifications with documentation references for operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->