### PR TITLE
CNI misconfigured notification

### DIFF
--- a/hcp/customer_cni_misconfiguration.json
+++ b/hcp/customer_cni_misconfiguration.json
@@ -1,0 +1,9 @@
+{
+  "severity": "Major",
+  "service_name": "SREManualAction",
+  "log_type": "cluster-configuration",
+  "summary": "Action required: Customer-managed CNI issue detected",
+  "description": "Your cluster was created without a default CNI plugin and a CNI-related issue has been detected: ${REASON}. Please verify that your CNI plugin is correctly deployed and configured. Red Hat does not provide support for third-party CNI plugins. Please contact your CNI vendor for assistance if needed.",
+  "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cni"],
+  "internal_only": false
+}


### PR DESCRIPTION
ROSA HCP allows clusters to be created without a CNI plugin, expecting the customer to deploy their own. When the CNI is not deployed or misconfigured, cluster operators like ingress, DNS, and image-registry fail because pods cannot be scheduled. SRE currently has no template to communicate this to the customer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new SRE manual action to detect and alert on clusters with missing default customer-managed CNI configuration, marked as major severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->