### PR TITLE
Add subnet tags missing service log for AutoNode

### DIFF
--- a/hcp/autonode/custom_subnet_tags_missing.json
+++ b/hcp/autonode/custom_subnet_tags_missing.json
@@ -1,0 +1,10 @@
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "summary": "Action required: AutoNode OpenShiftEC2NodeClass not ready due to subnet selector mismatch",
+    "description": "Red Hat has identified that your cluster's AutoNode OpenShiftEC2NodeClass ${NODECLASS_NAME} is not ready because the subnet selectors defined in your custom OpenShiftEC2NodeClass do not match any subnets in your VPC. Please ensure the subnet tags in your VPC match the selectors specified in your OpenShiftEC2NodeClass. Without matching subnets, AutoNode cannot provision new nodes.",
+    "internal_only": false,
+    "doc_references": [
+        "https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-vpc-subnet-tagging_rosa-hcp-sts-creating-a-cluster-quickly"
+    ]
+}

--- a/hcp/autonode/default_subnet_tags_missing.json
+++ b/hcp/autonode/default_subnet_tags_missing.json
@@ -1,0 +1,10 @@
+{
+    "severity": "Warning",
+    "service_name": "SREManualAction",
+    "summary": "Action required: AutoNode default OpenShiftEC2NodeClass not ready due to missing subnet tags",
+    "description": "Red Hat has identified that your cluster's default AutoNode OpenShiftEC2NodeClass is not ready because the required tags are missing from your VPC subnets. The default OpenShiftEC2NodeClass requires subnets to have the following tags: ${SUBNET_TAGS}. Please ensure your BYOVPC subnets have the required tags applied. Without these tags, AutoNode cannot discover subnets and will be unable to provision new nodes.",
+    "internal_only": false,
+    "doc_references": [
+        "https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-vpc-subnet-tagging_rosa-hcp-sts-creating-a-cluster-quickly"
+    ]
+}


### PR DESCRIPTION
## Summary
- Add service log template for when the default OpenshiftEC2NodeClass is not ready due to missing subnet tags on BYOVPC clusters
- Parameterized `SUBNET_TAG` (private: `kubernetes.io/role/internal-elb`, public: `kubernetes.io/role/elb`) and `INFRA_ID`
- Links to ROSA HCP subnet tagging documentation

## Related
- ops-sop PR: https://github.com/openshift/ops-sop/pull/4059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing warnings for AutoNode subnet configuration issues.
  * Alerts now explain when subnet selectors do not match or required default subnet tags are missing.
  * Included guidance for correcting subnet tags and links to relevant documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->