### PR TITLE
feat: add notification for CronJob timezone parsing failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,7 @@ Example:
 
 ```bash
 osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
-  -t https://raw.githubusercontent.com/openshift/managed-notifications/\
-master/osd/aws/InstallFailed_TooManyBuckets.json
+  -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
 ```
 
 ### Tag System

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ osdctl servicelog post <cluster-uuid> -t <template-url>
 Example:
 
 ```bash
-osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
+osdctl servicelog post -C aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
   -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Example:
 
 ```bash
 osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
-  -t https://raw.githubusercontent.com/openshift/managed-notifications/\
-master/osd/aws/InstallFailed_TooManyBuckets.json
+  -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
 ```
 
 Note: `Osdctl` supports the usage of the unique cluster name, or the

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ osdctl servicelog post <cluster UUID> -t <notificationTemplateUrl>
 Example:
 
 ```bash
-osdctl servicelog post aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
+osdctl servicelog post -C aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
   -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_TooManyBuckets.json
 ```
 

--- a/hcp/sts_deleted_provider.json
+++ b/hcp/sts_deleted_provider.json
@@ -4,6 +4,6 @@
   "log_type": "cluster-configuration",
   "summary": "Action required: Review OpenIDConnect provider configuration",
   "description": "Your cluster requires you to take action because the OpenIDConnect provider for this cluster could not be found. Please revert any changes to the OIDC provider to maintain ongoing cluster support.",
-  "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly"],
+  "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly"],
   "internal_only": false
 }

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -4,6 +4,6 @@
     "log_type": "cluster-configuration",
     "summary": "Action required: Bad MachineConfigPool Configuration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made to the cluster MachineConfigPool. ${REASON}. Please revert these changes or consult the documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html for details.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#rosa-managing-worker-nodes"],
+    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes"],
     "internal_only": false
 }

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -4,6 +4,6 @@
     "log_type": "cluster-configuration",
     "summary": "Action required: Bad MachineConfigPool Configuration",
     "description": "Your cluster requires you to take action. SRE has observed that there have been unsupported changes made to the cluster MachineConfigPool. ${REASON}. Please revert these changes or consult the documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html for details.",
-    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes"],
+    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-managing-worker-nodes"],
     "internal_only": false
 }

--- a/osd/aws/Failed_to_parse_cron_job_schedule.json
+++ b/osd/aws/Failed_to_parse_cron_job_schedule.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Please upgrade your cluster",
-    "description": "Your cluster version ${CURRENT_CLUSTER_VERSION}, does not support custom timezone configuration for cron jobs. Please upgrade your cluster to ${TARGET_CLUSTER_VERSION} to support custom timezone configuration. Please refer to this article for details: https://access.redhat.com/solutions/7145341",
+    "description": "Your cluster version ${CURRENT_CLUSTER_VERSION} does not support custom timezone configuration for cron jobs. Please upgrade your cluster to ${TARGET_CLUSTER_VERSION} to support custom timezone configuration. Please refer to this article for details: https://access.redhat.com/solutions/7145341",
     "doc_references": ["https://access.redhat.com/solutions/7145341"],
     "internal_only": false
 }

--- a/osd/aws/Failed_to_parse_cron_job_schedule.json
+++ b/osd/aws/Failed_to_parse_cron_job_schedule.json
@@ -1,0 +1,9 @@
+{
+    "severity": "Major",
+    "service_name": "SREManualAction",
+    "log_type": "cluster-configuration",
+    "summary": "Action required: Please upgrade your cluster",
+    "description": "Your cluster version ${CURRENT_CLUSTER_VERSION}, does not support custom timezone configuration for cron jobs. Please upgrade your cluster to ${TARGET_CLUSTER_VERSION} to support custom timezone configuration. Please refer to this article for details: https://access.redhat.com/solutions/7145341",
+    "doc_references": ["https://access.redhat.com/solutions/7145341"],
+    "internal_only": false
+}

--- a/osd/aws/Failed_to_parse_cron_job_schedule.json
+++ b/osd/aws/Failed_to_parse_cron_job_schedule.json
@@ -3,7 +3,7 @@
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Please upgrade your cluster",
-    "description": "Your cluster version ${CURRENT_CLUSTER_VERSION} does not support custom timezone configuration for cron jobs. Please upgrade your cluster to ${TARGET_CLUSTER_VERSION} to support custom timezone configuration. Please refer to this article for details: https://access.redhat.com/solutions/7145341",
+    "description": "Your cluster version ${CURRENT_CLUSTER_VERSION} does not support custom timezone configuration for cron jobs. Please upgrade your cluster to ${TARGET_CLUSTER_VERSION} to support custom timezone configuration. Please refer to this article for details: https://access.redhat.com/solutions/7145341.",
     "doc_references": ["https://access.redhat.com/solutions/7145341"],
     "internal_only": false
 }

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -4,6 +4,6 @@
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html.",
-    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#machine-pools"],
+    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#machine-pools"],
     "internal_only": false
 }

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -4,6 +4,6 @@
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. You need to either reduce application load or increase worker nodes. See the following documentation for scaling up worker nodes: https://docs.openshift.com/dedicated/nodes/rosa-managing-worker-nodes.html.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#machine-pools"],
+    "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#machine-pools"],
     "internal_only": false
 }

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -4,6 +4,6 @@
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/latest/cicd/pipelines/reducing-pipelines-resource-consumption.html#.",
-    "doc_references": ["https://docs.openshift.com/pipelines/latest/resource/reducing-pipelines-resource-consumption.html#.","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#machine-pools"],
+    "doc_references": ["https://docs.openshift.com/pipelines/latest/resource/reducing-pipelines-resource-consumption.html#.","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#machine-pools"],
     "internal_only": false
 }

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -4,6 +4,6 @@
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",
     "description": "Your cluster does not have enough resources and requires you to take action. SRE is aware of a condition affecting your cluster, it may be beneficial to reduce resource consumption of pipelines: https://docs.openshift.com/container-platform/latest/cicd/pipelines/reducing-pipelines-resource-consumption.html#.",
-    "doc_references": ["https://docs.openshift.com/pipelines/latest/resource/reducing-pipelines-resource-consumption.html#.","https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/manage-nodes-using-machine-pools#machine-pools"],
+    "doc_references": ["https://docs.openshift.com/pipelines/latest/resource/reducing-pipelines-resource-consumption.html#.","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-scaling-worker-nodes_rosa-managing-worker-nodes","https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#machine-pools"],
     "internal_only": false
 }


### PR DESCRIPTION
Add service log template to notify cluster owners when their cluster version does not support custom timezone configuration for cron jobs. This requires upgrading to a version that supports the timezone field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Alerts**
  * Added a manual-action alert for clusters without custom time zone support for scheduled jobs.
  * Included upgrade guidance and relevant documentation links to help operators address affected configurations.

* **Documentation**
  * Updated service log command examples with the correct cluster option and template URL.
  * Refreshed references for worker-node scaling, machine pools, and related troubleshooting guidance.
  * Corrected links to current Red Hat documentation across cluster alerts and operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->