### PR TITLE
fix: unify documentation URLs in GenericQuotaExceeded

### DIFF
--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -4,6 +4,6 @@
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",
     "description": "Your cluster's ${CLUSTER_FUNCTION} is blocked on a GCP ${RESOURCE_QUOTA} error. Please raise the related quota or free enough resources for the action to succeed. GCP account requirements are described in this document: https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs.",
-    "doc_references": ["https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"],
+    "doc_references": ["https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-requirements_gcp-ccs"],
     "internal_only": false
 }


### PR DESCRIPTION
Update doc_references to use the new docs.redhat.com domain to match the URL in the description field. Both URLs now consistently point to the same documentation using the updated domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quota-exceeded error reference link to point to the current Red Hat documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->