### PR TITLE
Add SL for ingress co down 

### DIFF
--- a/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
+++ b/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
@@ -1,0 +1,7 @@
+{
+    "severity": "Error",
+    "service_name": "SREManualAction",
+    "summary": "Installation blocked, action required",
+    "description": "Your cluster's installation is blocked due to insufficient IP space in subnet ${SUBNET}, preventing the default LoadBalancer from being created. The minimum number of IP addresses for internet-facing LoadBalancers is documented in: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones.",
+    "internal_only": false
+}

--- a/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
+++ b/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
@@ -2,6 +2,6 @@
     "severity": "Error",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
-    "description": "Your cluster's installation is blocked due to insufficient IP space in subnet ${SUBNET}, preventing the default LoadBalancer from being created. The minimum number of IP addresses for internet-facing LoadBalancers is documented in: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones.",
+    "description": "Your cluster's installation is blocked due to insufficient IP space in subnet ${SUBNET}, preventing the default LoadBalancer from being created. The minimum number of IP addresses for internet-facing LoadBalancers is documented in: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/availability-zones.html.",
     "internal_only": false
 }

--- a/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
+++ b/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Error",
+    "severity": "Major",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to insufficient IP space in subnet ${SUBNET}, preventing the default LoadBalancer from being created. The minimum number of IP addresses for internet-facing LoadBalancers is documented in: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/availability-zones.html.",


### PR DESCRIPTION
when lb creation fails due to not enough ips in subnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear installation error message when insufficient subnet IP space prevents creation of the default load balancer.
  * Included relevant AWS documentation guidance for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->