### PR TITLE
Migrate OCM severity labels to Important/Moderate/Low (ROSAENG-62697)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Each notification is a JSON file with required fields:
 
 ```json
 {
-  "severity": "Debug|Info|Warning|Major|Critical",
+  "severity": "Debug|Low|Moderate|Important|Critical",
   "service_name": "SREManualAction|...",
   "log_type": "cluster-lifecycle|...",
   "summary": "Brief summary.",
@@ -61,7 +61,7 @@ Each notification is a JSON file with required fields:
 **Key constraints:**
 
 - `description` field MUST end with a period (enforced by `make validate`)
-- `severity` must be one of: Debug, Info, Warning, Major, Critical
+- `severity` must be one of: Debug, Low, Moderate, Important, Critical
   (enforced by `scripts/checkseverity.sh`)
 - Templates may contain variable placeholders like `${TIME}`, `${CLUSTER_ID}`,
   `${NAMESPACE}`

--- a/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
+++ b/hcp/InstallFailed_InsufficientSubnetIPSpace_LoadBalancer.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "summary": "Installation blocked, action required",
     "description": "Your cluster's installation is blocked due to insufficient IP space in subnet ${SUBNET}, preventing the default LoadBalancer from being created. The minimum number of IP addresses for internet-facing LoadBalancers is documented in: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/availability-zones.html.",

--- a/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
+++ b/hcp/OCPBUGS_14611_Leftover_PersistentVolume.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster uninstall left behind PersistentVolume(s)",

--- a/hcp/Operator_Workload_Scheduling_Issue.json
+++ b/hcp/Operator_Workload_Scheduling_Issue.json
@@ -1,5 +1,5 @@
 {
-      "severity": "Major",
+      "severity": "Important",
       "service_name": "SREManualAction",
       "log_type": "cluster-lifecycle",
       "summary": "Operator workload scheduling issue requires action",

--- a/hcp/RequestServingNode_resized.json
+++ b/hcp/RequestServingNode_resized.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "cluster-scaling",
   "summary": "ROSA HCP Control Plane Scaled",

--- a/hcp/WorkerNodes_Stopped_error.json
+++ b/hcp/WorkerNodes_Stopped_error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Worker node(s) stopped, action required",

--- a/hcp/autonode/custom_subnet_tags_missing.json
+++ b/hcp/autonode/custom_subnet_tags_missing.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "summary": "Action required: AutoNode OpenShiftEC2NodeClass not ready due to subnet selector mismatch",
     "description": "Red Hat has identified that your cluster's AutoNode OpenShiftEC2NodeClass ${NODECLASS_NAME} is not ready because the subnet selectors defined in your custom OpenShiftEC2NodeClass do not match any subnets in your VPC. Please ensure the subnet tags in your VPC match the selectors specified in your OpenShiftEC2NodeClass. Without matching subnets, AutoNode cannot provision new nodes.",

--- a/hcp/autonode/default_subnet_tags_missing.json
+++ b/hcp/autonode/default_subnet_tags_missing.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "summary": "Action required: AutoNode default OpenShiftEC2NodeClass not ready due to missing subnet tags",
     "description": "Red Hat has identified that your cluster's default AutoNode OpenShiftEC2NodeClass is not ready because the required tags are missing from your VPC subnets. The default OpenShiftEC2NodeClass requires subnets to have the following tags: ${SUBNET_TAGS}. Please ensure your BYOVPC subnets have the required tags applied. Without these tags, AutoNode cannot discover subnets and will be unable to provision new nodes.",

--- a/hcp/customer_cni_misconfiguration.json
+++ b/hcp/customer_cni_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Customer-managed CNI issue detected",

--- a/hcp/end_of_support_force_upgrade.json
+++ b/hcp/end_of_support_force_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-upgrades",
   "summary": "Hosted Control Plane end-of-life upgrade has been initiated",

--- a/hcp/eus_transition_attempted.json
+++ b/hcp/eus_transition_attempted.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "cluster-upgrades",
   "summary": "Attempted transition to EUS channel - Resolution in progress",

--- a/hcp/eus_transition_success.json
+++ b/hcp/eus_transition_success.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "cluster-upgrades",
   "summary": "Cluster transitioned to EUS channel to extend support lifecycle",

--- a/hcp/hcp_aws_kms_permissions_issue.json
+++ b/hcp/hcp_aws_kms_permissions_issue.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/hcp/ip_range_is_full.json
+++ b/hcp/ip_range_is_full.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "General Notification",
   "_tags": ["t_network"],

--- a/hcp/logForwarding/cloudwatch_log_group_not_found.json
+++ b/hcp/logForwarding/cloudwatch_log_group_not_found.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Log forwarding failed, action required",

--- a/hcp/logForwarding/cloudwatch_log_group_permission_denied.json
+++ b/hcp/logForwarding/cloudwatch_log_group_permission_denied.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Log forwarding failed, action required",

--- a/hcp/logForwarding/s3_bucket_not_found.json
+++ b/hcp/logForwarding/s3_bucket_not_found.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Log forwarding failed, action required",

--- a/hcp/logForwarding/s3_bucket_permission_denied.json
+++ b/hcp/logForwarding/s3_bucket_permission_denied.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Log forwarding failed, action required",

--- a/hcp/logForwarding/sre_insufficient_permissions.json
+++ b/hcp/logForwarding/sre_insufficient_permissions.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Log forwarding issue requires customer action",

--- a/hcp/node_ip_range_is_full.json
+++ b/hcp/node_ip_range_is_full.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "General Notification",
   "_tags": ["t_network"],

--- a/hcp/sts_deleted_provider.json
+++ b/hcp/sts_deleted_provider.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review OpenIDConnect provider configuration",

--- a/hcp/webhook_blocking_nodepool_update.json
+++ b/hcp/webhook_blocking_nodepool_update.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Webhook blocking pod eviction during nodepool update",

--- a/osd/AddonMisconfiguration.json
+++ b/osd/AddonMisconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "_tags": ["t_config"],

--- a/osd/AlertmanagerSilencesActiveSRE.json
+++ b/osd/AlertmanagerSilencesActiveSRE.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "AlertManager Silences Identified",

--- a/osd/BadMachineConfigPool.json
+++ b/osd/BadMachineConfigPool.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Bad MachineConfigPool Configuration",

--- a/osd/BadMachinePoolTaint.json
+++ b/osd/BadMachinePoolTaint.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Incorrect MachinePool Configuration",

--- a/osd/DockerCIDROverlap45Install.json
+++ b/osd/DockerCIDROverlap45Install.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "_tags": ["t_network"],

--- a/osd/ElasticsearchClusterMisconfigured.json
+++ b/osd/ElasticsearchClusterMisconfigured.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: review cluster logging configuration",

--- a/osd/ElasticsearchClusterNotEnoughResources_Error.json
+++ b/osd/ElasticsearchClusterNotEnoughResources_Error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Elasticsearch impacted by cluster resource limits",

--- a/osd/ElasticsearchClusterNotHealthy_Error.json
+++ b/osd/ElasticsearchClusterNotHealthy_Error.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",

--- a/osd/ElasticsearchClusterNotHealthy_Warning.json
+++ b/osd/ElasticsearchClusterNotHealthy_Warning.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "event_stream_id": "${EVENT_STREAM_ID}",

--- a/osd/Failed_Logins.json
+++ b/osd/Failed_Logins.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-security",
   "summary": "There are an elevated number of failed logins on your cluster",

--- a/osd/InvalidCIDR.json
+++ b/osd/InvalidCIDR.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "_tags": ["t_network", "t_config"],

--- a/osd/KubePersistentVolumeFillingUpError-user.json
+++ b/osd/KubePersistentVolumeFillingUpError-user.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Persistent Volume filling",

--- a/osd/KubePersistentVolumeFillingUpError.json
+++ b/osd/KubePersistentVolumeFillingUpError.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Urgent action required: update cluster logging configuration",

--- a/osd/KubePersistentVolumeFillingUpWarn.json
+++ b/osd/KubePersistentVolumeFillingUpWarn.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: update cluster logging configuration",

--- a/osd/MultipleDefaultStorageClasses.json
+++ b/osd/MultipleDefaultStorageClasses.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Multiple Default Storage Classes Configured",

--- a/osd/Multiple_OCPBUGs_install_failure.json
+++ b/osd/Multiple_OCPBUGs_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/NetworkMigrationBlocked.json
+++ b/osd/NetworkMigrationBlocked.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-networking",
     "summary": "Action Required: Network Plugin Migration Blocked",

--- a/osd/NetworkMisconfiguration.json
+++ b/osd/NetworkMisconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_config", "t_network"],

--- a/osd/NodeFilesystemSpaceFillingUp-worker.json
+++ b/osd/NodeFilesystemSpaceFillingUp-worker.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "capacity-management",
   "summary": "Action required: Worker node mountpoint space nearly exhausted",

--- a/osd/Non_Red_Hat_Access_Core_Secrets.json
+++ b/osd/Non_Red_Hat_Access_Core_Secrets.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-security",
   "summary": "Non-Red Hat Access Core Secrets",

--- a/osd/Non_System_Change_SRE_API_Endpoint.json
+++ b/osd/Non_System_Change_SRE_API_Endpoint.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Non-System Change SRE API Endpoint",

--- a/osd/OCM3018_rosa_STS_machine_api_role.json
+++ b/osd/OCM3018_rosa_STS_machine_api_role.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "OCM3018 Installation blocked, action required",

--- a/osd/OCPBUGS-16655-remediation-please-upgrade.json
+++ b/osd/OCPBUGS-16655-remediation-please-upgrade.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-updates",
   "summary": "Cluster impacted by OCPBUGS-16655, upgrade recommended",

--- a/osd/OCPBUGS6494_4_12_install_failure.json
+++ b/osd/OCPBUGS6494_4_12_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/OCPBUG_install_failure.json
+++ b/osd/OCPBUG_install_failure.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/OperatorMisconfigured.json
+++ b/osd/OperatorMisconfigured.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "_tags": ["t_config"],

--- a/osd/PlatformComponentNonRedHat.json
+++ b/osd/PlatformComponentNonRedHat.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Platform component accessed by non-Red Hat SRE user",

--- a/osd/PodNetworkCIDRExhaustion.json
+++ b/osd/PodNetworkCIDRExhaustion.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "General Notification",
   "_tags": ["t_network"],

--- a/osd/RHOAMInstallNeedsMoreResources.json
+++ b/osd/RHOAMInstallNeedsMoreResources.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-add-ons",
   "summary": "Action required: Add resources to complete RHOAM installation",

--- a/osd/RecoveryOfDeletedMaster.json
+++ b/osd/RecoveryOfDeletedMaster.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Recovery of deleted master nodes is not supported",

--- a/osd/ResourceIsRaisingClusterAlert.json
+++ b/osd/ResourceIsRaisingClusterAlert.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Resource/s ${RESOURCE} in ${NAMESPACE_OR_CLUSTER_SCOPE} is triggering a alert",

--- a/osd/RosaInstallationFailedOnInvalidIamRoles.json
+++ b/osd/RosaInstallationFailedOnInvalidIamRoles.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation failed (invalid IAM roles)",

--- a/osd/StuckNewBuilds3MinSRE.json
+++ b/osd/StuckNewBuilds3MinSRE.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: update cluster build configuration",

--- a/osd/User_Forbidden.json
+++ b/osd/User_Forbidden.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-security",
   "summary": "Elevated rate of failed authorization events on your Managed OpenShift cluster",

--- a/osd/aws/AWS_Marketplace_acknowledgement.json
+++ b/osd/aws/AWS_Marketplace_acknowledgement.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster machine creation blocked, action required.",

--- a/osd/aws/AWS_outage.json
+++ b/osd/aws/AWS_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "AWS Outage Impacting Your Cluster",

--- a/osd/aws/AWS_zone_outage.json
+++ b/osd/aws/AWS_zone_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "AWS Availability Zone Outage Impacting Your Cluster",

--- a/osd/aws/AddressLimitExceeded.json
+++ b/osd/aws/AddressLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/AlertmanagerSilencesActiveSRE.json
+++ b/osd/aws/AlertmanagerSilencesActiveSRE.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Clear Alertmanager Silences",

--- a/osd/aws/ClusterGoneMissing_NetworkIssue
+++ b/osd/aws/ClusterGoneMissing_NetworkIssue
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: review firewall configuration",

--- a/osd/aws/Failed_to_parse_cron_job_schedule.json
+++ b/osd/aws/Failed_to_parse_cron_job_schedule.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Please upgrade your cluster",

--- a/osd/aws/GenericQuotaExceeded.json
+++ b/osd/aws/GenericQuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",

--- a/osd/aws/InstallFailed_AWSS3Change.json
+++ b/osd/aws/InstallFailed_AWSS3Change.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",

--- a/osd/aws/InstallFailed_AWS_Capacity.json
+++ b/osd/aws/InstallFailed_AWS_Capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
+++ b/osd/aws/InstallFailed_BucketRequestRateTooHigh.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_CreateServiceLinkedRole.json
+++ b/osd/aws/InstallFailed_CreateServiceLinkedRole.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidCustomTag.json
+++ b/osd/aws/InstallFailed_InvalidCustomTag.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidDHCPOptionset.json
+++ b/osd/aws/InstallFailed_InvalidDHCPOptionset.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_InvalidSubnet.json
+++ b/osd/aws/InstallFailed_InvalidSubnet.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
+++ b/osd/aws/InstallFailed_MultipleRoute53ZonesFound.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Duplicate hosted zones",

--- a/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
+++ b/osd/aws/InstallFailed_NATGatewayPrivateSubnet.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_Generic.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
+++ b/osd/aws/InstallFailed_NetworkMisconfigured_PrivateLink.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_NoRouteToInternet.json
+++ b/osd/aws/InstallFailed_NoRouteToInternet.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked: Missing route to internet",

--- a/osd/aws/InstallFailed_PrivateLink_Firewall.json
+++ b/osd/aws/InstallFailed_PrivateLink_Firewall.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
+++ b/osd/aws/InstallFailed_PrivateLink_subnetEgress.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_ProxyBadTLS.json
+++ b/osd/aws/InstallFailed_ProxyBadTLS.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "summary": "Installation blocked: Proxy malfunction",
   "description": "Your cluster's installation is blocked because the configured cluster-wide proxy is not properly initiating TLS handshakes for HTTPS connections. Please review your network and proxy configuration and retry cluster installation. Seet the following documentation for more details on cluster-wide proxies: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/ovn-kubernetes_network_plugin/configuring-a-cluster-wide-proxy.",

--- a/osd/aws/InstallFailed_QuotaExceeded.json
+++ b/osd/aws/InstallFailed_QuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_RoleDeletionFailed.json
+++ b/osd/aws/InstallFailed_RoleDeletionFailed.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_STS_PrivateLink.json
+++ b/osd/aws/InstallFailed_STS_PrivateLink.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_SecurityGroupBeingModified.json
+++ b/osd/aws/InstallFailed_SecurityGroupBeingModified.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_TempAWSError.json
+++ b/osd/aws/InstallFailed_TempAWSError.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster installation failed",

--- a/osd/aws/InstallFailed_TooManyBucketObjectTags.json
+++ b/osd/aws/InstallFailed_TooManyBucketObjectTags.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_TooManyBuckets.json
+++ b/osd/aws/InstallFailed_TooManyBuckets.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_lambda_automation_interfering.json
+++ b/osd/aws/InstallFailed_lambda_automation_interfering.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/InstallFailed_proxy_unreachable.json
+++ b/osd/aws/InstallFailed_proxy_unreachable.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "summary": "Installation blocked: Missing route to internet",
   "description": "Your cluster's installation is blocked because of the cluster-wide proxy configured is not reachable. Please review the network and proxy configuration before reattempting cluster installation process: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/ovn-kubernetes_network_plugin/configuring-a-cluster-wide-proxy.",

--- a/osd/aws/NodeStuckTerminating.json
+++ b/osd/aws/NodeStuckTerminating.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "AWS Delayed Instance Termination",

--- a/osd/aws/ROSA_AWS_KMS_permissions_required.json
+++ b/osd/aws/ROSA_AWS_KMS_permissions_required.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/ROSA_AWS_invalid_permissions.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-access",
     "summary": "Installation blocked, action required",

--- a/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
+++ b/osd/aws/ROSA_AWS_invalid_permissions_with_reason.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/SubnetAddressRangeFull.json
+++ b/osd/aws/SubnetAddressRangeFull.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "General Notification",
   "_tags": ["t_network"],

--- a/osd/aws/TagPolicyBlocksInstanceCreation.json
+++ b/osd/aws/TagPolicyBlocksInstanceCreation.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "summary": "Cluster degraded, action required",
     "description": "Your cluster requires action because the machine-api operator is unable to provision new instances. Red Hat has determined that an AWS Tag Policy is causing the issue. Please remove the tag policy that enforces the 'ProductOwnerEmail' tag key to restore full functionality.",

--- a/osd/aws/VPCEndpointLimitExceeded.json
+++ b/osd/aws/VPCEndpointLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/VPCLimitExceeded.json
+++ b/osd/aws/VPCLimitExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/aws/aws_outage_resolved.json
+++ b/osd/aws/aws_outage_resolved.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "customer-support",
   "summary": "RESOLVED: AWS Outage Impacting Your Cluster",

--- a/osd/aws/sts_thumbprint.json
+++ b/osd/aws/sts_thumbprint.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: update cluster OIDC thumbprint",

--- a/osd/aws/unable_to_create_machines_aws_capacity.json
+++ b/osd/aws/unable_to_create_machines_aws_capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster machine creation blocked, action required",

--- a/osd/cluster-wide_proxy_ca_expiring.json
+++ b/osd/cluster-wide_proxy_ca_expiring.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: Cluster proxy CA Expiring",

--- a/osd/cluster_alerting_with_no_sre_access.json
+++ b/osd/cluster_alerting_with_no_sre_access.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-access",
     "summary": "Attention requested: Cluster account access unavailable",

--- a/osd/cluster_cannot_be_recovered.json
+++ b/osd/cluster_cannot_be_recovered.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/cluster_overloaded.json
+++ b/osd/cluster_overloaded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",

--- a/osd/cluster_proxy_misconfiguration.json
+++ b/osd/cluster_proxy_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: update cluster proxy configuration",

--- a/osd/cluster_stuck.json
+++ b/osd/cluster_stuck.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "Action required: Cluster Stuck",

--- a/osd/clustertransfer_completed.json
+++ b/osd/clustertransfer_completed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Cluster Ownership Transfer Successfully Completed",

--- a/osd/clustertransfer_starting.json
+++ b/osd/clustertransfer_starting.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Cluster Ownership Transfer Initiated",

--- a/osd/controlplane_resized.json
+++ b/osd/controlplane_resized.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",
     "event_stream_id": "${JIRA_ID}",

--- a/osd/custom_ingress_controller_misconfiguration.json
+++ b/osd/custom_ingress_controller_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type":"cluster-networking",
   "summary": "Action required: update cluster configuration",

--- a/osd/customer_alert_blocking_upgrade.json
+++ b/osd/customer_alert_blocking_upgrade.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-updates",
   "summary": "Action required: Cluster Upgrade Blocked",

--- a/osd/customer_alert_paging.json
+++ b/osd/customer_alert_paging.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: a custom alert is paging Red Hat",

--- a/osd/customer_clusteroperator_down.json
+++ b/osd/customer_clusteroperator_down.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action required: Remove or address failing cluster operator",

--- a/osd/customer_emptydir_storage_preventing_drain.json
+++ b/osd/customer_emptydir_storage_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",
     "summary": "Action required: Pod emptydir storage preventing Node Drain",

--- a/osd/customer_pdb_preventing_drain.json
+++ b/osd/customer_pdb_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",

--- a/osd/customer_pdb_preventing_drain_automated.json
+++ b/osd/customer_pdb_preventing_drain_automated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Pod Disruption Budget(s) preventing Node Drain",

--- a/osd/customer_pod_preventing_drain.json
+++ b/osd/customer_pod_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod(s) preventing Node Drain",

--- a/osd/customer_pods_preventing_drain_automated.json
+++ b/osd/customer_pods_preventing_drain_automated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Pod(s) preventing Node Drain",

--- a/osd/customer_stopped_control_plane_node.json
+++ b/osd/customer_stopped_control_plane_node.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Action required: Restart control plane node",

--- a/osd/eol_date_extended.json
+++ b/osd/eol_date_extended.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Product end-of-life date extended",

--- a/osd/gcp/GCP_Network_Misconfig.json
+++ b/osd/gcp/GCP_Network_Misconfig.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Action required: Failed Openshift Installation on GCP",

--- a/osd/gcp/GCP_Service_API_Disabled.json
+++ b/osd/gcp/GCP_Service_API_Disabled.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: enable required service APIs",

--- a/osd/gcp/GCP_WIF_invalid_permissions.json
+++ b/osd/gcp/GCP_WIF_invalid_permissions.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Installation blocked, action required",

--- a/osd/gcp/GCP_WIF_invalid_support_role.json
+++ b/osd/gcp/GCP_WIF_invalid_support_role.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: fix Workload Identity Federation (WIF) support role to maintain SRE support",

--- a/osd/gcp/GCP_infranode_resized_auto.json
+++ b/osd/gcp/GCP_infranode_resized_auto.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "_tags": ["t_config"],
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",

--- a/osd/gcp/GCP_outage.json
+++ b/osd/gcp/GCP_outage.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "GCP Outage Impacting Your Cluster",

--- a/osd/gcp/GCP_outage_resolved.json
+++ b/osd/gcp/GCP_outage_resolved.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "RESOLVED: GCP Outage Impacting Your Cluster",

--- a/osd/gcp/GPC_WIF_update_configuration.json
+++ b/osd/gcp/GPC_WIF_update_configuration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: update cluster Workload Identity Federation (WIF) configuration",

--- a/osd/gcp/GenericQuotaExceeded.json
+++ b/osd/gcp/GenericQuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: review account quota",

--- a/osd/gcp/InstallFailed_GCP_Capacity.json
+++ b/osd/gcp/InstallFailed_GCP_Capacity.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/gcp/InstallFailed_OCPBUGS-43821.json
+++ b/osd/gcp/InstallFailed_OCPBUGS-43821.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/gcp/InstallFailed_QuotaExceeded.json
+++ b/osd/gcp/InstallFailed_QuotaExceeded.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Installation blocked, action required",

--- a/osd/gcp/invalid_iaas_credentials.json
+++ b/osd/gcp/invalid_iaas_credentials.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Restore missing cloud credentials",

--- a/osd/gcp/unable_to_create_machine_invalid_type.json
+++ b/osd/gcp/unable_to_create_machine_invalid_type.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster machine creation blocked, action required",

--- a/osd/generic_deprovision_failed.json
+++ b/osd/generic_deprovision_failed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Deprovision failed, action required",

--- a/osd/generic_install_failed.json
+++ b/osd/generic_install_failed.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecycle",
   "summary": "Installation blocked, action required",

--- a/osd/hive_migration.json
+++ b/osd/hive_migration.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "${DATE} Upcoming Maintenance: OpenShift Cluster Manager actions will be unavailable during this maintenance",

--- a/osd/idp_has_connectivity_problems.json
+++ b/osd/idp_has_connectivity_problems.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_network", "t_config"],

--- a/osd/ignore_previous_message.json
+++ b/osd/ignore_previous_message.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "customer-support",
     "summary": "Please ignore previous message",

--- a/osd/incident_declared.json
+++ b/osd/incident_declared.json
@@ -1,6 +1,6 @@
 {
   "event_stream_id": "${INCIDENT_ID}",
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "summary": "Cluster incident identified",
   "description": "Your cluster is identified to have a failure that is currently under investigation. The initial issue can be described as '${BRIEF_DESCRIPTION}'.",

--- a/osd/incident_resolved.json
+++ b/osd/incident_resolved.json
@@ -1,6 +1,6 @@
 {
   "event_stream_id": "${INCIDENT_ID}",
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "summary": "Cluster incident resolved",
   "description": "Cluster incident is resolved.",

--- a/osd/incident_update.json
+++ b/osd/incident_update.json
@@ -1,6 +1,6 @@
 {
   "event_stream_id": "${INCIDENT_ID}",
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "summary": "Cluster incident update",
   "description": "${INCIDENT_UPDATE_MESSAGE}. Please refer to support case ${CASE_ID} for communication with our team, where there is opportunity for ongoing dialogue.",

--- a/osd/incorrect_PodDisruptionBudget.json
+++ b/osd/incorrect_PodDisruptionBudget.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: Incorrect Pod Disruption Budget configuration",

--- a/osd/infranode_resized.json
+++ b/osd/infranode_resized.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",
     "event_stream_id": "${JIRA_ID}",

--- a/osd/infranode_resized_auto.json
+++ b/osd/infranode_resized_auto.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "_tags": ["t_config"],
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",

--- a/osd/infranode_volume_type_changed.json
+++ b/osd/infranode_volume_type_changed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Infra Node EBS Volume Type Changed",

--- a/osd/install_failed_please_retry.json
+++ b/osd/install_failed_please_retry.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Installation blocked, action required",

--- a/osd/invalid_customer_ic.json
+++ b/osd/invalid_customer_ic.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: Invalid ingress configuration",

--- a/osd/invalid_iaas_credentials.json
+++ b/osd/invalid_iaas_credentials.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Restore missing cloud credentials",

--- a/osd/invalid_iam_role.json
+++ b/osd/invalid_iam_role.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Action required: Fix AWS Role to maintain SRE support",

--- a/osd/invalid_ingress_component_route.json
+++ b/osd/invalid_ingress_component_route.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action Required: Invalid ingress component route(s)",

--- a/osd/invalid_registry_policy.json
+++ b/osd/invalid_registry_policy.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: container registry policy invalid",

--- a/osd/limited_support/EOLClusterStillSupported.json
+++ b/osd/limited_support/EOLClusterStillSupported.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "end-of-life-extension",
   "summary": "Cluster is fully supported and has been granted end of life cycle extension",

--- a/osd/limited_support/EOLExtension.json
+++ b/osd/limited_support/EOLExtension.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Info",
+  "severity": "Low",
   "service_name": "SREManualAction",
   "log_type": "end-of-life-extension",
   "summary": "Cluster is fully supported and has been granted end of life cycle extension until ${EXTENSION_DATE}",

--- a/osd/limited_support/GovcloudLimitedSupportOneClusterPerVPC.json
+++ b/osd/limited_support/GovcloudLimitedSupportOneClusterPerVPC.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "kind": "LimitedSupportReason",
   "summary": "Cluster is in Limited Support due to unsupported network configuration",
   "details": "SRE has observed that there is more than 1 cluster within a single VPC in your AWS account. VPC sharing is not supported within AWS GovCloud Regions for ROSA Classic. Please use the ROSA UI or CLI to remove one of these clusters from the VPC for this cluster. If this cluster will be the one remaining in the VPC when completed, please open a ServiceNow case for SRE to review and remove this status",

--- a/osd/limited_support/LimitedSupportCloud.json
+++ b/osd/limited_support/LimitedSupportCloud.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "summary": "Cluster is in Limited Support due to unsupported cloud provider configuration",
     "log_type": "cluster-configuration",
     "details": "${CONFIGURATION}",

--- a/osd/limited_support/LimitedSupportCluster.json
+++ b/osd/limited_support/LimitedSupportCluster.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "log_type": "cluster-configuration",
     "summary": "Cluster is in Limited Support due to unsupported cluster configuration",
     "details": "${CONFIGURATION}",

--- a/osd/limited_support/egressFailureLimitedSupport.json
+++ b/osd/limited_support/egressFailureLimitedSupport.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "kind": "LimitedSupportReason",
   "details": "Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support. Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/prepare_your_environment/index#firewalls",
   "detection_type": "manual",

--- a/osd/limited_support/scheduled_chaos_test.json
+++ b/osd/limited_support/scheduled_chaos_test.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "summary": "Cluster is in Limited Support due to scheduled chaos testing",
     "log_type": "customer-support",
     "details": "Your cluster is in Limited Support due to a scheduled chaos test. Chaos testing includes AZ outage testing, network testing, disaster recovery testing, etc. Once your testing is complete, please reach out to Red Hat Support to resume full-support of your cluster",

--- a/osd/maintenance_completed.json
+++ b/osd/maintenance_completed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "${DATE} Cluster maintenance successfully completed",

--- a/osd/maintenance_starting.json
+++ b/osd/maintenance_starting.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "${DATE} Cluster maintenance is starting",

--- a/osd/monitoring_stack_broken.json
+++ b/osd/monitoring_stack_broken.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/no_resources_to_run_userworkloadmonitoring.json
+++ b/osd/no_resources_to_run_userworkloadmonitoring.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: User Workload Monitoring impacted by cluster resource limits",

--- a/osd/obo_deprecation.json
+++ b/osd/obo_deprecation.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Deprecation Notice: Observability Operator",

--- a/osd/obo_post_deprecation.json
+++ b/osd/obo_post_deprecation.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Deprecation Complete: Observability Operator",

--- a/osd/osd_too_old_upgrade_needed.json
+++ b/osd/osd_too_old_upgrade_needed.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action required: Upgrade cluster before ${CUTOFF_DATE}",

--- a/osd/persistentvolume_resized.json
+++ b/osd/persistentvolume_resized.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Persistent Volume/s Resized",

--- a/osd/pipelines_resource_problem.json
+++ b/osd/pipelines_resource_problem.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "capacity-management",
     "summary": "Action required: Resources overloaded",

--- a/osd/pull_secret_change_breaking_upgradesync.json
+++ b/osd/pull_secret_change_breaking_upgradesync.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/pull_secret_multiple_sync_failures.json
+++ b/osd/pull_secret_multiple_sync_failures.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/pull_secret_rotated.json
+++ b/osd/pull_secret_rotated.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster pull secret updated",

--- a/osd/pull_secret_user_mismatch.json
+++ b/osd/pull_secret_user_mismatch.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Review pull secret",

--- a/osd/recovered_master_node.json
+++ b/osd/recovered_master_node.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecyle",
     "summary": "SRE recovered master nodes",

--- a/osd/request_customer_managed_ingress.json
+++ b/osd/request_customer_managed_ingress.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type":"cluster-networking",
   "summary": "Action required: update cluster configuration",

--- a/osd/required_network_egresses_are_blocked.json
+++ b/osd/required_network_egresses_are_blocked.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "summary": "Action required: Network misconfiguration",

--- a/osd/resize_master_etcd_bz_2068601
+++ b/osd/resize_master_etcd_bz_2068601
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-scaling",
     "summary": "${DATE}: Control plane resize to ${INSTANCE_TYPE} beginning",

--- a/osd/rosa_STS_invalid_permissions.json
+++ b/osd/rosa_STS_invalid_permissions.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-access",
   "summary": "Installation blocked, action required",

--- a/osd/rosa_cert_signed_by_unknown_authority.json
+++ b/osd/rosa_cert_signed_by_unknown_authority.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network"],

--- a/osd/rosa_cluster_cannot_be_recovered.json
+++ b/osd/rosa_cluster_cannot_be_recovered.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-lifecyle",
   "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/rosa_cluster_cant_manage_instances.json
+++ b/osd/rosa_cluster_cant_manage_instances.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster degraded, action required",

--- a/osd/rosa_cluster_destroyed_cluster_admin.json
+++ b/osd/rosa_cluster_destroyed_cluster_admin.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-lifecycle",
     "summary": "Cluster destroyed, cannot be recovered",

--- a/osd/rosa_clusterlogging_general.json
+++ b/osd/rosa_clusterlogging_general.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster Logging configuration",

--- a/osd/rosa_clusterlogging_loki.json
+++ b/osd/rosa_clusterlogging_loki.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Update Cluster LokiStack Logging configuration",

--- a/osd/rosa_customer_pdb_preventing_drain.json
+++ b/osd/rosa_customer_pdb_preventing_drain.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Pod Disruption Budget preventing Node Drain",

--- a/osd/rosa_invalid_tls_cert.json
+++ b/osd/rosa_invalid_tls_cert.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-networking",
     "summary": "Invalid TLS certificate",

--- a/osd/rosa_no_egress_route.json
+++ b/osd/rosa_no_egress_route.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-networking",
   "_tags": ["t_network", "t_config"],

--- a/osd/rosa_scp_misconfigured_invalid_permission.json
+++ b/osd/rosa_scp_misconfigured_invalid_permission.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/sdn_to_ovn_migration_investigation.json
+++ b/osd/sdn_to_ovn_migration_investigation.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "SRE is investigating delays in SDN to OVN migration",

--- a/osd/security_update_available.json
+++ b/osd/security_update_available.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-security",
     "summary": "Important security update available",

--- a/osd/silence_namespace_alerts_notice.json
+++ b/osd/silence_namespace_alerts_notice.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Info",
+    "severity": "Low",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "NOTICE: Silencing alerts for 'openshift-*' user namespaces",

--- a/osd/termination_protection.json
+++ b/osd/termination_protection.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "_tags": ["t_config"],

--- a/osd/unable_to_create_machine_invalid_type.json
+++ b/osd/unable_to_create_machine_invalid_type.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Cluster machine creation blocked, action required",

--- a/osd/unevictable_workload.json
+++ b/osd/unevictable_workload.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Unevictable workload detected",

--- a/osd/unknown_failure.json
+++ b/osd/unknown_failure.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Cluster incident identified",

--- a/osd/unschedulable_customer_pod.json
+++ b/osd/unschedulable_customer_pod.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/upgrade_blocked.json
+++ b/osd/upgrade_blocked.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",

--- a/osd/upgrade_blocked_with_docs.json
+++ b/osd/upgrade_blocked_with_docs.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Upgrade Blocked and Unable to Complete, Action Required",

--- a/osd/upgrade_cluster_version.json
+++ b/osd/upgrade_cluster_version.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Warning",
+    "severity": "Moderate",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action Required: Upgrade cluster version",

--- a/osd/upgrade_paused_acknowledgement.json
+++ b/osd/upgrade_paused_acknowledgement.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-updates",
     "summary": "Action Required: Cluster upgrade paused, requires acknowledgement",

--- a/osd/uwm_misconfiguration.json
+++ b/osd/uwm_misconfiguration.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "_tags": ["t_config"],

--- a/osd/validating_webhook_configurations.json
+++ b/osd/validating_webhook_configurations.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Platform protections removed by non-Red Hat user",

--- a/osd/workernode_overloaded.json
+++ b/osd/workernode_overloaded.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "capacity-management",
   "summary": "Action required: Cluster health impacted by missing resource limits",

--- a/osd/workernode_overloaded_pid_limit_rosa.json
+++ b/osd/workernode_overloaded_pid_limit_rosa.json
@@ -1,5 +1,5 @@
 {
-    "severity": "Major",
+    "severity": "Important",
     "service_name": "SREManualAction",
     "log_type": "cluster-configuration",
     "summary": "Action required: Cluster health impacted by High Pod PID Limits",

--- a/osd/workload_deployed_in_restricted_project.json
+++ b/osd/workload_deployed_in_restricted_project.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Major",
+  "severity": "Important",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Action required: Fix workload deployed in a restricted project",

--- a/rosa/PlatformComponentNonRedHat.json
+++ b/rosa/PlatformComponentNonRedHat.json
@@ -1,5 +1,5 @@
 {
-  "severity": "Warning",
+  "severity": "Moderate",
   "service_name": "SREManualAction",
   "log_type": "cluster-configuration",
   "summary": "Platform component accessed by non-Red Hat SRE user",

--- a/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
+++ b/rosa/limited_support/CertificateRenewalBlockedByInstallerRole.json
@@ -1,6 +1,6 @@
 {
     "kind": "LimitedSupportReason",
-    "severity": "Warning",
+    "severity": "Moderate",
     "summary": "Cluster is in Limited Support due to Blocked Installer Role IAM Access",
     "details": "Access to the Installer Role: ${ROLE_NAME} is currently being blocked. This can lead to failing important cluster management functions including but not limited to certificate renewals, which will cause loss of access to the cluster. Please remediate this issue in order to restore support",
     "doc_references": ["https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/rosa-sts-about-iam-resources"],

--- a/scripts/checkseverity.sh
+++ b/scripts/checkseverity.sh
@@ -9,8 +9,8 @@ do
   fi
 
   # This is a pretty rough check, ideally we move this repo to a json schema validation in the future
-  if ! jq -e '.severity == "Debug" or .severity == "Info" or .severity == "Warning" or .severity == "Major" or .severity == "Critical"'  < "$file" > /dev/null 2>&1; then
-    echo "file $file has invalid 'severity' value! must be one of 'Debug', 'Info', 'Warning', 'Major', 'Critical'"
+  if ! jq -e '.severity == "Debug" or .severity == "Low" or .severity == "Moderate" or .severity == "Important" or .severity == "Critical"'  < "$file" > /dev/null 2>&1; then
+    echo "file $file has invalid 'severity' value! must be one of 'Debug', 'Low', 'Moderate', 'Important', 'Critical'"
     exit 1
   fi
 done < <(find . -type f -name "*.json" -not -path "./mcp/*" -print0)


### PR DESCRIPTION
Migrates OCM service log severity labels to align with new OCM naming: Major→Important, Warning→Moderate, Info→Low (Critical/Debug unchanged). Updates all 205 affected notification templates plus `scripts/checkseverity.sh` and `CLAUDE.md` docs in the same commit.

Part of [ROSAENG-62697](https://redhat.atlassian.net/browse/ROSAENG-62697) (deadline 2026-09-28, when OCM Service Log API stops accepting the old labels). Independent of the ocm-agent-operator CRD change (openshift/ocm-agent-operator#368) — these templates are posted manually via `osdctl servicelog post` and don't go through that CRD.

Jira: https://issues.redhat.com/browse/ROSAENG-62697